### PR TITLE
Wave spectrum asset

### DIFF
--- a/src/unity/Assets/Crest-Examples/Scenes/main.unity
+++ b/src/unity/Assets/Crest-Examples/Scenes/main.unity
@@ -790,8 +790,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _rasterMesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
   _waveShader: {fileID: 4800000, guid: 680b41329a8923e40a8f9d6ca86f60a8, type: 3}
-  _spectrum: {fileID: 0}
+  _spectrum: {fileID: 11400000, guid: 454d1b08383f089479cf6794620926f4, type: 2}
   _componentsPerOctave: 5
+  _weight: 1
   _randomSeed: 0
 --- !u!1 &1899543705
 GameObject:

--- a/src/unity/Assets/Crest-Examples/Scenes/main.unity
+++ b/src/unity/Assets/Crest-Examples/Scenes/main.unity
@@ -155,6 +155,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _showSimTargets: 1
   _guiVisible: 1
+  _oceanMaterialAsset: Assets/Crest/Shaders/Materials/Ocean.mat
 --- !u!20 &227134469
 Camera:
   m_ObjectHideFlags: 0
@@ -756,7 +757,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1866213578}
   - component: {fileID: 1866213581}
-  - component: {fileID: 1866213579}
   m_Layer: 8
   m_Name: OceanWavesBatched
   m_TagString: Untagged
@@ -777,37 +777,6 @@ Transform:
   m_Father: {fileID: 995304123}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1866213579
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1866213577}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 60efd8af8fbfdee4bb291bb685fad3a2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _weight: 1
-  _componentsPerOctave: 5
-  _waveDirectionVariance: 90
-  _powerLog:
-  - -6
-  - -4.0088496
-  - -3.4452133
-  - -2.6996124
-  - -2.615044
-  - -1.2080691
-  - -0.53905386
-  - 0.27448857
-  - 0.53627354
-  - 1.0282621
-  - 1.4403292
-  - -6
-  _powerDisabled: 000000000000000000000000
-  _windSpeed: 11.833333
-  _fetch: 459237
-  _chop: 1
 --- !u!114 &1866213581
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -821,6 +790,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _rasterMesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
   _waveShader: {fileID: 4800000, guid: 680b41329a8923e40a8f9d6ca86f60a8, type: 3}
+  _spectrum: {fileID: 0}
+  _componentsPerOctave: 5
   _randomSeed: 0
 --- !u!1 &1899543705
 GameObject:

--- a/src/unity/Assets/Crest-Examples/WaveSpectra.meta
+++ b/src/unity/Assets/Crest-Examples/WaveSpectra.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1ff1a8ffde63b834ea5371e795011f05
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/unity/Assets/Crest-Examples/WaveSpectra/WavesModerate.asset
+++ b/src/unity/Assets/Crest-Examples/WaveSpectra/WavesModerate.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 33068fc021dadc04dab6e00e4ff45c00, type: 3}
+  m_Name: WavesModerate
+  m_EditorClassIdentifier: 
+  _waveDirectionVariance: 90
+  _powerLog:
+  - -6
+  - -4.0088496
+  - -3.4452133
+  - -2.9986157
+  - -2.615044
+  - -1.2080691
+  - -0.53905386
+  - 0.27448857
+  - 0.53627354
+  - 1.0282621
+  - 1.4403292
+  - -6
+  _powerDisabled: 000000000000000000000000
+  _chop: 1

--- a/src/unity/Assets/Crest-Examples/WaveSpectra/WavesModerate.asset.meta
+++ b/src/unity/Assets/Crest-Examples/WaveSpectra/WavesModerate.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 454d1b08383f089479cf6794620926f4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/unity/Assets/Crest/Scripts/Editor/OceanWaveSpectrumEditor.cs
+++ b/src/unity/Assets/Crest/Scripts/Editor/OceanWaveSpectrumEditor.cs
@@ -11,6 +11,9 @@ namespace Crest
         private static GUIStyle ToggleButtonStyleNormal = null;
         private static GUIStyle ToggleButtonStyleToggled = null;
 
+        static float _windSpeed = 10f;
+        static float _fetch = 500000f;
+
         public override void OnInspectorGUI()
         {
             base.OnInspectorGUI();
@@ -68,11 +71,10 @@ namespace Crest
             EditorGUILayout.LabelField("Empirical Spectra", EditorStyles.boldLabel);
 
             EditorGUILayout.BeginHorizontal();
-            var spWindSpeed = serializedObject.FindProperty("_windSpeed");
-            float spd_kmh = spWindSpeed.floatValue * 3.6f;
+            float spd_kmh = _windSpeed * 3.6f;
             EditorGUILayout.LabelField("Wind speed (km/h)", GUILayout.Width(120f));
             spd_kmh = EditorGUILayout.Slider(spd_kmh, 0f, 60f);
-            spWindSpeed.floatValue = spd_kmh / 3.6f;
+            _windSpeed = spd_kmh / 3.6f;
             EditorGUILayout.EndHorizontal();
 
 
@@ -85,7 +87,7 @@ namespace Crest
             if (spec._applyPhillipsSpectrum)
             {
                 spec._applyJONSWAPSpectrum = spec._applyPiersonMoskowitzSpectrum = false;
-                spec.ApplyPhillipsSpectrum(spWindSpeed.floatValue);
+                spec.ApplyPhillipsSpectrum(_windSpeed);
             }
 
             if (GUILayout.Button(new GUIContent("Pierson-Moskowitz", "Fully developed sea with infinite fetch"), spec._applyPiersonMoskowitzSpectrum ? ToggleButtonStyleToggled : ToggleButtonStyleNormal))
@@ -95,13 +97,10 @@ namespace Crest
             if (spec._applyPiersonMoskowitzSpectrum)
             {
                 spec._applyPhillipsSpectrum = spec._applyJONSWAPSpectrum = false;
-                spec.ApplyPiersonMoskowitzSpectrum(spWindSpeed.floatValue);
+                spec.ApplyPiersonMoskowitzSpectrum(_windSpeed);
             }
 
-            EditorGUILayout.BeginHorizontal();
-            var spFetch = serializedObject.FindProperty("_fetch");
-            spFetch.floatValue = EditorGUILayout.Slider("Fetch", spFetch.floatValue, 0f, 1000000f);
-            EditorGUILayout.EndHorizontal();
+            _fetch = EditorGUILayout.Slider("Fetch", _fetch, 0f, 1000000f);
 
 
             if (GUILayout.Button(new GUIContent("JONSWAP", "Fetch limited sea where waves continue to grow"), spec._applyJONSWAPSpectrum ? ToggleButtonStyleToggled : ToggleButtonStyleNormal))
@@ -111,7 +110,7 @@ namespace Crest
             if (spec._applyJONSWAPSpectrum)
             {
                 spec._applyPhillipsSpectrum = spec._applyPiersonMoskowitzSpectrum = false;
-                spec.ApplyJONSWAPSpectrum(spWindSpeed.floatValue);
+                spec.ApplyJONSWAPSpectrum(_windSpeed, _fetch);
             }
 
 

--- a/src/unity/Assets/Crest/Scripts/Editor/OceanWaveSpectrumEditor.cs
+++ b/src/unity/Assets/Crest/Scripts/Editor/OceanWaveSpectrumEditor.cs
@@ -5,16 +5,14 @@ using UnityEngine;
 
 namespace Crest
 {
-    [CustomEditor( typeof(WaveSpectrum) )]
-    public class WaveSpectrumEditor : Editor
+    [CustomEditor( typeof(OceanWaveSpectrum) )]
+    public class OceanWaveSpectrumEditor : Editor
     {
         private static GUIStyle ToggleButtonStyleNormal = null;
         private static GUIStyle ToggleButtonStyleToggled = null;
 
         public override void OnInspectorGUI()
         {
-            EditorGUILayout.HelpBox("This component is deprecated and will remove itself at runtime, use OceanWaveSpectrum assets instead.", MessageType.Warning);
-
             base.OnInspectorGUI();
 
             // preamble - styles for toggle buttons. this code and the below was based off the useful info provided by user Lasse here:
@@ -46,7 +44,7 @@ namespace Crest
             EditorGUILayout.LabelField("Spectrum", EditorStyles.boldLabel);
             EditorGUILayout.EndHorizontal();
 
-            var spec = target as WaveSpectrum;
+            var spec = target as OceanWaveSpectrum;
 
             var spPower = serializedObject.FindProperty("_powerLog");
             
@@ -57,10 +55,10 @@ namespace Crest
                 var spDisabled_i = spDisabled.GetArrayElementAtIndex(i);
                 spDisabled_i.boolValue = !EditorGUILayout.Toggle(!spDisabled_i.boolValue, GUILayout.Width(15f));
 
-                float smallWL = WaveSpectrum.SmallWavelength(i);
+                float smallWL = OceanWaveSpectrum.SmallWavelength(i);
                 EditorGUILayout.LabelField(string.Format("{0}", smallWL), GUILayout.Width(30f));
                 var spPower_i = spPower.GetArrayElementAtIndex(i);
-                spPower_i.floatValue = GUILayout.HorizontalSlider(spPower_i.floatValue, WaveSpectrum.MIN_POWER_LOG, WaveSpectrum.MAX_POWER_LOG);
+                spPower_i.floatValue = GUILayout.HorizontalSlider(spPower_i.floatValue, OceanWaveSpectrum.MIN_POWER_LOG, OceanWaveSpectrum.MAX_POWER_LOG);
 
                 EditorGUILayout.EndHorizontal();
             }

--- a/src/unity/Assets/Crest/Scripts/Editor/OceanWaveSpectrumEditor.cs.meta
+++ b/src/unity/Assets/Crest/Scripts/Editor/OceanWaveSpectrumEditor.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: ced045179bda726468243872c430ed8c
+timeCreated: 1497217877
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/unity/Assets/Crest/Scripts/Editor/WaveSpectrumEditor.cs
+++ b/src/unity/Assets/Crest/Scripts/Editor/WaveSpectrumEditor.cs
@@ -55,7 +55,7 @@ namespace Crest
                 var spDisabled_i = spDisabled.GetArrayElementAtIndex(i);
                 spDisabled_i.boolValue = !EditorGUILayout.Toggle(!spDisabled_i.boolValue, GUILayout.Width(15f));
 
-                float smallWL = spec.SmallWavelength(i);
+                float smallWL = WaveSpectrum.SmallWavelength(i);
                 EditorGUILayout.LabelField(string.Format("{0}", smallWL), GUILayout.Width(30f));
                 var spPower_i = spPower.GetArrayElementAtIndex(i);
                 spPower_i.floatValue = GUILayout.HorizontalSlider(spPower_i.floatValue, WaveSpectrum.MIN_POWER_LOG, WaveSpectrum.MAX_POWER_LOG);

--- a/src/unity/Assets/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
+++ b/src/unity/Assets/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
@@ -14,9 +14,6 @@ namespace Crest
         public static readonly float MIN_POWER_LOG = -6f;
         public static readonly float MAX_POWER_LOG = 3f;
 
-        [Range(0f, 1f)]
-        public float _weight = 1f;
-
         [Tooltip("Variance of flow direction, in degrees"), Range(0f, 180f)]
         public float _waveDirectionVariance = 90f;
 
@@ -25,15 +22,7 @@ namespace Crest
             { -6f, -4.0088496f, -3.4452133f, -2.6996124f, -2.615044f, -1.2080691f, -0.53905386f, 0.27448857f, 0.53627354f, 1.0282621f, 1.4403292f, -6f };
 
         [SerializeField, HideInInspector]
-        public bool[] _powerDisabled = new bool[NUM_OCTAVES];
-
-        // should this just be an argument to the spectrum calculation, and a temporary UI var?
-        [HideInInspector]
-        public float _windSpeed = 10f;
-
-        // should this just be an argument to the spectrum calculation, and a temporary UI var?
-        [HideInInspector]
-        public float _fetch = 1000000f;
+        bool[] _powerDisabled = new bool[NUM_OCTAVES];
 
         [Tooltip("Scales horizontal displacement"), Range(0f, 2f)]
         public float _chop = 1f;
@@ -77,7 +66,7 @@ namespace Crest
 
             float a_2 = 2f * Mathf.Pow(10f, _powerLog[index]) * domega;
             var a = Mathf.Sqrt(a_2);
-            return a * _weight;
+            return a;
         }
 
         float ComputeWaveSpeed(float wavelength/*, float depth*/)
@@ -157,7 +146,7 @@ namespace Crest
             }
         }
 
-        public void ApplyJONSWAPSpectrum(float windSpeed)
+        public void ApplyJONSWAPSpectrum(float windSpeed, float fetch)
         {
 #if UNITY_EDITOR
             UnityEditor.Undo.RecordObject(this, "Apply JONSWAP Spectrum");
@@ -166,7 +155,7 @@ namespace Crest
             for (int octave = 0; octave < NUM_OCTAVES; octave++)
             {
                 float wl = SmallWavelength(octave) * 1.5f;
-                var pow = JONSWAPSpectrum(Mathf.Abs(Physics.gravity.y), windSpeed, wl, _fetch);
+                var pow = JONSWAPSpectrum(Mathf.Abs(Physics.gravity.y), windSpeed, wl, fetch);
                 // we store power on logarithmic scale. this does not include 0, we represent 0 as min value
                 pow = Mathf.Max(pow, Mathf.Pow(10f, MIN_POWER_LOG));
                 _powerLog[octave] = Mathf.Log10(pow);

--- a/src/unity/Assets/Crest/Scripts/Shapes/OceanWaveSpectrum.cs.meta
+++ b/src/unity/Assets/Crest/Scripts/Shapes/OceanWaveSpectrum.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 33068fc021dadc04dab6e00e4ff45c00
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/unity/Assets/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/src/unity/Assets/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -9,13 +9,17 @@ namespace Crest
     /// Support script for Gerstner wave ocean shapes.
     /// Generates a number of batches of Gerstner waves.
     /// </summary>
-    [RequireComponent(typeof(WaveSpectrum))]
     public class ShapeGerstnerBatched : MonoBehaviour, ICollProvider
     {
         [Tooltip("Geometry to rasterize into wave buffers to generate waves.")]
         public Mesh _rasterMesh;
         [Tooltip("Shader to be used to render out a single Gerstner octave.")]
         public Shader _waveShader;
+        [Tooltip("The spectrum that defines the ocean surface shape.")]
+        public OceanWaveSpectrum _spectrum;
+
+        [Delayed]
+        public int _componentsPerOctave = 5;
 
         public int _randomSeed = 0;
 
@@ -26,7 +30,6 @@ namespace Crest
         float[] _phases;
 
         // useful references
-        WaveSpectrum _spectrum;
         Material[] _materials;
         Material _materialBigWaveTransition;
         CommandBuffer[] _renderWaveShapeCmdBufs;
@@ -44,7 +47,7 @@ namespace Crest
 
         void Start()
         {
-            _spectrum = GetComponent<WaveSpectrum>();
+            _spectrum = _spectrum ?? ScriptableObject.CreateInstance<OceanWaveSpectrum>();
         }
 
         void Update()
@@ -53,7 +56,7 @@ namespace Crest
             Random.State randomStateBkp = Random.state;
             Random.InitState(_randomSeed);
 
-            _spectrum.GenerateWaveData(ref _wavelengths, ref _angleDegs, ref _phases);
+            _spectrum.GenerateWaveData(_componentsPerOctave, ref _wavelengths, ref _angleDegs, ref _phases);
 
             Random.state = randomStateBkp;
 
@@ -83,7 +86,7 @@ namespace Crest
 
             for (int i = 0; i < _wavelengths.Length; i++)
             {
-                _amplitudes[i] = _spectrum.GetAmplitude(_wavelengths[i]);
+                _amplitudes[i] = _spectrum.GetAmplitude(_wavelengths[i], _componentsPerOctave);
             }
         }
 

--- a/src/unity/Assets/Crest/Scripts/Shapes/WaveSpectrum.cs
+++ b/src/unity/Assets/Crest/Scripts/Shapes/WaveSpectrum.cs
@@ -45,9 +45,7 @@ namespace Crest
             }
         }
 
-        public float SmallestWavelength { get { return Mathf.Pow(2f, SMALLEST_WL_POW_2); } }
-        public float SmallWavelength(float octaveIndex) { return Mathf.Pow(2f, SMALLEST_WL_POW_2 + octaveIndex); }
-        public float LargeWavelength(float octaveIndex) { return Mathf.Pow(2f, SMALLEST_WL_POW_2 + octaveIndex + 1f); }
+        public static float SmallWavelength(float octaveIndex) { return Mathf.Pow(2f, SMALLEST_WL_POW_2 + octaveIndex); }
 
         public float GetAmplitude(float wavelength)
         {

--- a/src/unity/Assets/Crest/Shaders/OceanLODData.cginc
+++ b/src/unity/Assets/Crest/Shaders/OceanLODData.cginc
@@ -69,6 +69,7 @@ float ComputeLodAlpha(float3 i_worldPos, float i_meshScaleAlpha)
 	// taxicab distance from ocean center drives LOD transitions
 	float2 offsetFromCenter = float2(abs(i_worldPos.x - _OceanCenterPosWorld.x), abs(i_worldPos.z - _OceanCenterPosWorld.z));
 	float taxicab_norm = max(offsetFromCenter.x, offsetFromCenter.y);
+
 	// interpolation factor to next lod (lower density / higher sampling period)
 	float lodAlpha = taxicab_norm / _WD_Pos_Scale_0.z - 1.0;
 
@@ -77,8 +78,10 @@ float ComputeLodAlpha(float3 i_worldPos, float i_meshScaleAlpha)
 	// using .15 as black and .85 as white should work for base mesh density as low as 16. TODO - make this automatic?
 	const float BLACK_POINT = 0.15, WHITE_POINT = 0.85;
 	lodAlpha = max((lodAlpha - BLACK_POINT) / (WHITE_POINT - BLACK_POINT), 0.);
+
 	// blend out lod0 when viewpoint gains altitude
 	lodAlpha = min(lodAlpha + i_meshScaleAlpha, 1.);
+
 #if _DEBUGDISABLESMOOTHLOD_ON
 	lodAlpha = 0.;
 #endif


### PR DESCRIPTION
@Midda-C @dizzy2003

In this branch I have done long overdue refactoring and cleanup of how the wave shape/spectrum is authored. The spectrum is now defined in an asset, so you can generate multiple wave conditions. These are then rendered by the OceanGerstnerWaves component, with a weight. To blend between wave conditions, one can add two OceanGerstnerWaves components and give desired weights (its always add-blend). I thought of more complicate schemes (I have an RnD idea of smoothly blending spectra), but the above is simple and allows users to define blending how they want, and I'll see in the future if we promote any scheme(s) into Crest.

The old component for defining the wave shape - WaveSpectrum - is hereby deprecated. It has a warning to this effect in the inspector and will auto remove itself at runtime with a warning in the log. I'll leave it in there for while, so that people can get the data they need out of it and remove it.

I am moving towards semantic versioning to protect API/data and may help to lessen churn like this in the future. Getting the above sorted is a necessary step.

Anyway this was a heads up, if you have any comments about the changes themselves let me know!