### PR TITLE
Remove state from OceanBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Enjoy!
 
 * Ocean material / shading: The default ocean material *Ocean.mat* contains many tweakable variables to control appearance. Turn off unnecessary features to maximize performance.
 * Animated waves / ocean shape: Configured on the *ShapeGerstnerBatched* script by providing an *Ocean Wave Spectrum* asset. This asset has an equalizer-style interface for tweaking different scales of waves, and also has some parametric wave spectra from the literature for comparison.
-* Ocean foam: Configured on the *OceanBuilder* script by providing a *Sim Settings Foam* asset.
-* Dynamic wave simulation: Configured on the *OceanBuilder* script by providing a *Sim Settings Wave* asset.
+* Ocean foam: Configured on the *OceanRenderer* script by providing a *Sim Settings Foam* asset.
+* Dynamic wave simulation: Configured on the *OceanRenderer* script by providing a *Sim Settings Wave* asset.
 
 All settings can be live authored. When tweaking ocean shape it can be useful to freeze time (set *Time.timeScale* to 0) to clearly see the effect of each octave of waves.
 

--- a/src/unity/Assets/Crest-Examples/BoatDev/Scenes/boat.unity
+++ b/src/unity/Assets/Crest-Examples/BoatDev/Scenes/boat.unity
@@ -265,6 +265,7 @@ MonoBehaviour:
   - LodDataDynamicWaves
   - LodDataFoam
   _cullIncludeLayers: []
+  _logErrorIfLayerMissing: 1
 --- !u!114 &227134473
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -415,6 +416,7 @@ MonoBehaviour:
   _layerName: LodDataAnimatedWaves
   _cullExcludeLayers: []
   _cullIncludeLayers: []
+  _logErrorIfLayerMissing: 1
 --- !u!33 &723498134
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -497,6 +499,10 @@ Prefab:
       value: 48
       objectReference: {fileID: 0}
     - target: {fileID: 11447936, guid: 8454e29c2a033974fb559f5f8eff1918, type: 2}
+      propertyPath: _createDynamicWaveSim
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 11417796, guid: 8454e29c2a033974fb559f5f8eff1918, type: 2}
       propertyPath: _createDynamicWaveSim
       value: 1
       objectReference: {fileID: 0}
@@ -837,6 +843,7 @@ MonoBehaviour:
   _layerName: SimWave
   _cullExcludeLayers: []
   _cullIncludeLayers: []
+  _logErrorIfLayerMissing: 1
 --- !u!1 &1866213577
 GameObject:
   m_ObjectHideFlags: 0

--- a/src/unity/Assets/Crest-Examples/BoatDev/Scenes/threeboats.unity
+++ b/src/unity/Assets/Crest-Examples/BoatDev/Scenes/threeboats.unity
@@ -266,6 +266,7 @@ MonoBehaviour:
   - LodDataDynamicWaves
   - LodDataFoam
   _cullIncludeLayers: []
+  _logErrorIfLayerMissing: 1
 --- !u!114 &227134473
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -474,6 +475,10 @@ Prefab:
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 11447936, guid: 8454e29c2a033974fb559f5f8eff1918, type: 2}
+      propertyPath: _createDynamicWaveSim
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 11417796, guid: 8454e29c2a033974fb559f5f8eff1918, type: 2}
       propertyPath: _createDynamicWaveSim
       value: 1
       objectReference: {fileID: 0}
@@ -784,6 +789,7 @@ MonoBehaviour:
   _layerName: LodDataDynamicWaves
   _cullExcludeLayers: []
   _cullIncludeLayers: []
+  _logErrorIfLayerMissing: 1
 --- !u!1 &1866213577
 GameObject:
   m_ObjectHideFlags: 0

--- a/src/unity/Assets/Crest-Examples/Scripts/Interaction/InteractCapsule.cs
+++ b/src/unity/Assets/Crest-Examples/Scripts/Interaction/InteractCapsule.cs
@@ -32,7 +32,7 @@ public class InteractCapsule : MonoBehaviour
 
         float V = dy * A;
 
-        float VperLod = V / OceanRenderer.Instance.Builder.CurrentLodCount;
+        float VperLod = V / OceanRenderer.Instance.CurrentLodCount;
 
         _mat.SetFloat( "_displacedVPerLod", VperLod );
 

--- a/src/unity/Assets/Crest-Examples/Scripts/OceanDebugGUI.cs
+++ b/src/unity/Assets/Crest-Examples/Scripts/OceanDebugGUI.cs
@@ -78,7 +78,7 @@ public class OceanDebugGUI : MonoBehaviour
 
             int min = int.MaxValue, max = -1;
             bool readbackShape = true;
-            foreach( var ldaw in OceanRenderer.Instance.Builder._lodDataAnimWaves)
+            foreach( var ldaw in OceanRenderer.Instance._lodDataAnimWaves)
             {
                 min = Mathf.Min(min, ldaw.DataReadback.ReadbackRequestsQueued);
                 max = Mathf.Max(max, ldaw.DataReadback.ReadbackRequestsQueued);
@@ -87,7 +87,7 @@ public class OceanDebugGUI : MonoBehaviour
 #if UNITY_EDITOR
             if (readbackShape != GUI.Toggle(new Rect(x, y, w, h), readbackShape, "Readback coll data"))
             {
-                foreach (var ldaw in OceanRenderer.Instance.Builder._lodDataAnimWaves)
+                foreach (var ldaw in OceanRenderer.Instance._lodDataAnimWaves)
                 {
                     ldaw._readbackShapeForCollision = !readbackShape;
                 }
@@ -139,7 +139,7 @@ public class OceanDebugGUI : MonoBehaviour
     {
         {
             int ind = 0;
-            foreach (var cam in OceanRenderer.Instance.Builder._camsAnimWaves)
+            foreach (var cam in OceanRenderer.Instance._camsAnimWaves)
             {
                 if (!cam) continue;
 
@@ -148,7 +148,7 @@ public class OceanDebugGUI : MonoBehaviour
                 if (shape == null) continue;
 
                 float b = 7f;
-                float h = Screen.height / (float)OceanRenderer.Instance.Builder._camsAnimWaves.Length;
+                float h = Screen.height / (float)OceanRenderer.Instance._camsAnimWaves.Length;
                 float w = h + b;
                 float x = Screen.width - w;
                 float y = ind * h;
@@ -163,9 +163,9 @@ public class OceanDebugGUI : MonoBehaviour
         }
 
         // draw sim data
-        DrawSims(OceanRenderer.Instance.Builder._camsFoam, 2f);
-        DrawSims(OceanRenderer.Instance.Builder._camsDynWaves, 3f);
-        DrawSims(OceanRenderer.Instance.Builder._camsFlow, 4f);
+        DrawSims(OceanRenderer.Instance._camsFoam, 2f);
+        DrawSims(OceanRenderer.Instance._camsDynWaves, 3f);
+        DrawSims(OceanRenderer.Instance._camsFlow, 4f);
     }
 
     static void DrawSims(Camera[] simCameras, float offset)
@@ -179,7 +179,7 @@ public class OceanDebugGUI : MonoBehaviour
             if (shape == null) continue;
 
             float b = 7f;
-            float h = Screen.height / (float)OceanRenderer.Instance.Builder._camsAnimWaves.Length;
+            float h = Screen.height / (float)OceanRenderer.Instance._camsAnimWaves.Length;
             float w = h + b;
             float x = Screen.width - w * offset + b * (offset - 1f);
             float y = idx * h;

--- a/src/unity/Assets/Crest/Prefabs/Ocean.prefab
+++ b/src/unity/Assets/Crest/Prefabs/Ocean.prefab
@@ -8,7 +8,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 478202}
-  - component: {fileID: 11447936}
   - component: {fileID: 11417796}
   m_Layer: 0
   m_Name: Ocean
@@ -24,7 +23,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 147084}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -42,29 +41,29 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _viewpoint: {fileID: 0}
+  _material: {fileID: 2100000, guid: 9def92ac79181fe41b238e91663f0fad, type: 2}
+  _layerName: Water
   _windDirectionAngle: 0
+  _gravityMultiplier: 1
   _cachedCpuOceanQueries: 0
   _minTexelsPerWave: 3
   _minScale: 8
   _maxScale: 256
   _baseVertDensity: 64
   _lodCount: 7
+  _createFoamSim: 1
+  _simSettingsFoam: {fileID: 0}
+  _createDynamicWaveSim: 0
+  _simSettingsDynamicWaves: {fileID: 0}
+  _createFlowSim: 0
+  _simSettingsFlow: {fileID: 0}
   _uniformTiles: 0
   _disableSkirt: 0
---- !u!114 &11447936
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 147084}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ecf2b25b7104b034086ca7f8a62a7bea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _oceanMaterial: {fileID: 2100000, guid: 9def92ac79181fe41b238e91663f0fad, type: 2}
-  _shapeCameras: []
-  _shapeWDCs: []
+  _lodDataAnimWaves: []
+  _camsAnimWaves: []
+  _camsFoam: []
+  _camsFlow: []
+  _camsDynWaves: []
 --- !u!1001 &100100000
 Prefab:
   m_ObjectHideFlags: 1

--- a/src/unity/Assets/Crest/Scripts/Collision/CollProviderDispTexs.cs
+++ b/src/unity/Assets/Crest/Scripts/Collision/CollProviderDispTexs.cs
@@ -17,7 +17,7 @@ namespace Crest
         {
             int lod = LodDataAnimatedWaves.SuggestDataLOD(new Rect(worldPos.x, worldPos.z, 0f, 0f), 0f);
             if (lod == -1) return false;
-            return OceanRenderer.Instance.Builder._lodDataAnimWaves[lod].SampleDisplacement(ref worldPos, ref displacement);
+            return OceanRenderer.Instance._lodDataAnimWaves[lod].SampleDisplacement(ref worldPos, ref displacement);
         }
         public bool SampleDisplacement(ref Vector3 worldPos, ref Vector3 displacement, float minSpatialLength)
         {
@@ -31,7 +31,7 @@ namespace Crest
         {
             int lod = LodDataAnimatedWaves.SuggestDataLOD(new Rect(worldPos.x, worldPos.z, 0f, 0f), 0f);
             if (lod == -1) return false;
-            height = OceanRenderer.Instance.Builder._lodDataAnimWaves[lod].GetHeight(ref worldPos);
+            height = OceanRenderer.Instance._lodDataAnimWaves[lod].GetHeight(ref worldPos);
             return true;
         }
 
@@ -45,11 +45,11 @@ namespace Crest
         }
         public bool SampleDisplacementInArea(ref Vector3 worldPos, ref Vector3 displacement)
         {
-            return OceanRenderer.Instance.Builder._lodDataAnimWaves[_areaLod].SampleDisplacement(ref worldPos, ref displacement);
+            return OceanRenderer.Instance._lodDataAnimWaves[_areaLod].SampleDisplacement(ref worldPos, ref displacement);
         }
         public bool SampleHeightInArea(ref Vector3 worldPos, ref float height)
         {
-            height = OceanRenderer.Instance.Builder._lodDataAnimWaves[_areaLod].GetHeight(ref worldPos);
+            height = OceanRenderer.Instance._lodDataAnimWaves[_areaLod].GetHeight(ref worldPos);
             return true;
         }
 
@@ -62,7 +62,7 @@ namespace Crest
             // select lod. this now has a 1 texel buffer, so the finite differences below should all be valid.
             PrewarmForSamplingArea(new Rect(undisplacedWorldPos.x, undisplacedWorldPos.z, 0f, 0f), minSpatialLength);
 
-            float gridSize = OceanRenderer.Instance.Builder._lodDataAnimWaves[_areaLod].LodTransform._renderData._texelWidth;
+            float gridSize = OceanRenderer.Instance._lodDataAnimWaves[_areaLod].LodTransform._renderData._texelWidth;
 
             Vector3 dispCenter = Vector3.zero;
             if (!SampleDisplacementInArea(ref undisplacedWorldPos, ref dispCenter)) return false;

--- a/src/unity/Assets/Crest/Scripts/Helpers/RenderAlphaOnSurface.cs
+++ b/src/unity/Assets/Crest/Scripts/Helpers/RenderAlphaOnSurface.cs
@@ -39,7 +39,7 @@ namespace Crest
 
                 _rend.GetPropertyBlock(_mpb);
 
-                var ldaws = OceanRenderer.Instance.Builder._lodDataAnimWaves;
+                var ldaws = OceanRenderer.Instance._lodDataAnimWaves;
                 ldaws[idx].BindResultData(0, _mpb);
                 int idx1 = Mathf.Min(idx + 1, ldaws.Length - 1);
                 ldaws[idx1].BindResultData(1, _mpb);

--- a/src/unity/Assets/Crest/Scripts/LodData/LodData.cs
+++ b/src/unity/Assets/Crest/Scripts/LodData/LodData.cs
@@ -192,15 +192,15 @@ namespace Crest
         } }
         LodDataFoam _ldf;
         public LodDataFoam LDFoam { get {
-                return _ldf ?? (_ldf = OceanRenderer.Instance.Builder._camsFoam[LodTransform.LodIndex].GetComponent<LodDataFoam>());
+                return _ldf ?? (_ldf = OceanRenderer.Instance._camsFoam[LodTransform.LodIndex].GetComponent<LodDataFoam>());
         } }
         LodDataDynamicWaves _lddw;
         public LodDataDynamicWaves LDDynamicWaves { get {
-                return _lddw ?? (_lddw = OceanRenderer.Instance.Builder._camsDynWaves[LodTransform.LodIndex].GetComponent<LodDataDynamicWaves>());
+                return _lddw ?? (_lddw = OceanRenderer.Instance._camsDynWaves[LodTransform.LodIndex].GetComponent<LodDataDynamicWaves>());
         } }
         LodDataFlow _ldfl;
         public LodDataFlow LDFlow { get {
-                return _ldfl ?? (_ldfl = OceanRenderer.Instance.Builder._camsFlow[LodTransform.LodIndex].GetComponent<LodDataFlow>());
+                return _ldfl ?? (_ldfl = OceanRenderer.Instance._camsFlow[LodTransform.LodIndex].GetComponent<LodDataFlow>());
         } }
     }
 }

--- a/src/unity/Assets/Crest/Scripts/LodData/LodDataAnimatedWaves.cs
+++ b/src/unity/Assets/Crest/Scripts/LodData/LodDataAnimatedWaves.cs
@@ -55,11 +55,11 @@ namespace Crest
                 _bufCombineShapes = new CommandBuffer();
                 _bufCombineShapes.name = "Combine Displacements";
 
-                var cams = OceanRenderer.Instance.Builder._camsAnimWaves;
+                var cams = OceanRenderer.Instance._camsAnimWaves;
                 for (int L = cams.Length - 2; L >= 0; L--)
                 {
                     // accumulate shape data down the LOD chain - combine L+1 into L
-                    var mat = OceanRenderer.Instance.Builder._lodDataAnimWaves[L].CombineMaterial;
+                    var mat = OceanRenderer.Instance._lodDataAnimWaves[L].CombineMaterial;
                     _bufCombineShapes.Blit(cams[L + 1].targetTexture, cams[L].targetTexture, mat);
                 }
             }
@@ -122,7 +122,7 @@ namespace Crest
 
             if (LodTransform.LodIndex > 0)
             {
-                var ldaws = OceanRenderer.Instance.Builder._lodDataAnimWaves;
+                var ldaws = OceanRenderer.Instance._lodDataAnimWaves;
                 BindResultData(1, ldaws[LodTransform.LodIndex - 1].CombineMaterial);
             }
         }
@@ -222,7 +222,7 @@ namespace Crest
         }
         public static int SuggestDataLOD(Rect sampleAreaXZ, float minSpatialLength)
         {
-            var ldaws = OceanRenderer.Instance.Builder._lodDataAnimWaves;
+            var ldaws = OceanRenderer.Instance._lodDataAnimWaves;
             for (int lod = 0; lod < ldaws.Length; lod++)
             {
                 // shape texture needs to completely contain sample area

--- a/src/unity/Assets/Crest/Scripts/LodData/LodDataDynamicWaves.cs
+++ b/src/unity/Assets/Crest/Scripts/LodData/LodDataDynamicWaves.cs
@@ -13,7 +13,7 @@ namespace Crest
         public override SimType LodDataType { get { return SimType.DynamicWaves; } }
         protected override string ShaderSim { get { return "Ocean/Shape/Sim/2D Wave Equation"; } }
         public override RenderTextureFormat TextureFormat { get { return RenderTextureFormat.RGHalf; } }
-        protected override Camera[] SimCameras { get { return OceanRenderer.Instance.Builder._camsDynWaves; } }
+        protected override Camera[] SimCameras { get { return OceanRenderer.Instance._camsDynWaves; } }
 
         public override SimSettingsBase CreateDefaultSettings()
         {
@@ -87,7 +87,7 @@ namespace Crest
             {
                 _copySimResultsCmdBuf.Clear();
                 _copySimResultsCmdBuf.Blit(
-                    PPRTs.Target, OceanRenderer.Instance.Builder._camsAnimWaves[LodTransform.LodIndex].targetTexture, _copySimMaterial);
+                    PPRTs.Target, OceanRenderer.Instance._camsAnimWaves[LodTransform.LodIndex].targetTexture, _copySimMaterial);
             }
         }
 
@@ -103,7 +103,7 @@ namespace Crest
 
             // assign sea floor depth - to slot 1 current frame data. minor bug here - this depth will actually be from the previous frame,
             // because the depth is scheduled to render just before the animated waves, and this sim happens before animated waves.
-            OceanRenderer.Instance.Builder._lodDataAnimWaves[LodTransform.LodIndex].LDSeaDepth.BindResultData(1, simMaterial);
+            OceanRenderer.Instance._lodDataAnimWaves[LodTransform.LodIndex].LDSeaDepth.BindResultData(1, simMaterial);
         }
 
         private void OnDisable()
@@ -118,7 +118,7 @@ namespace Crest
         public static void CountWaveSims(int countFrom, out int present, out int active)
         {
             present = active = 0;
-            foreach (var ldaw in OceanRenderer.Instance.Builder._lodDataAnimWaves)
+            foreach (var ldaw in OceanRenderer.Instance._lodDataAnimWaves)
             {
                 if (ldaw.LDDynamicWaves == null)
                     continue;

--- a/src/unity/Assets/Crest/Scripts/LodData/LodDataFlow.cs
+++ b/src/unity/Assets/Crest/Scripts/LodData/LodDataFlow.cs
@@ -12,7 +12,7 @@ namespace Crest
         public override SimType LodDataType { get { return SimType.Flow; } }
         protected override string ShaderSim { get { return "Ocean/Shape/Sim/Flow"; } }
         public override RenderTextureFormat TextureFormat { get { return RenderTextureFormat.RGHalf; } }
-        protected override Camera[] SimCameras { get { return OceanRenderer.Instance.Builder._camsFlow; } }
+        protected override Camera[] SimCameras { get { return OceanRenderer.Instance._camsFlow; } }
 
         public override SimSettingsBase CreateDefaultSettings()
         {
@@ -28,9 +28,9 @@ namespace Crest
             simMaterial.SetFloat("_FlowSpeed", Settings._flowSpeed);
 
             // assign animated waves - to slot 1 current frame data
-            OceanRenderer.Instance.Builder._lodDataAnimWaves[LodTransform.LodIndex].BindResultData(1, simMaterial);
+            OceanRenderer.Instance._lodDataAnimWaves[LodTransform.LodIndex].BindResultData(1, simMaterial);
             // assign sea floor depth - to slot 1 current frame data
-            OceanRenderer.Instance.Builder._lodDataAnimWaves[LodTransform.LodIndex].LDSeaDepth.BindResultData(1, simMaterial);
+            OceanRenderer.Instance._lodDataAnimWaves[LodTransform.LodIndex].LDSeaDepth.BindResultData(1, simMaterial);
         }
 
         SimSettingsFlow Settings { get { return _settings as SimSettingsFlow; } }

--- a/src/unity/Assets/Crest/Scripts/LodData/LodDataFoam.cs
+++ b/src/unity/Assets/Crest/Scripts/LodData/LodDataFoam.cs
@@ -12,7 +12,7 @@ namespace Crest
         public override SimType LodDataType { get { return SimType.Foam; } }
         protected override string ShaderSim { get { return "Ocean/Shape/Sim/Foam"; } }
         public override RenderTextureFormat TextureFormat { get { return RenderTextureFormat.RHalf; } }
-        protected override Camera[] SimCameras { get { return OceanRenderer.Instance.Builder._camsFoam; } }
+        protected override Camera[] SimCameras { get { return OceanRenderer.Instance._camsFoam; } }
 
         public override SimSettingsBase CreateDefaultSettings()
         {
@@ -32,9 +32,9 @@ namespace Crest
             simMaterial.SetFloat("_ShorelineFoamStrength", Settings._shorelineFoamStrength);
 
             // assign animated waves - to slot 1 current frame data
-            OceanRenderer.Instance.Builder._lodDataAnimWaves[LodTransform.LodIndex].BindResultData(1, simMaterial);
+            OceanRenderer.Instance._lodDataAnimWaves[LodTransform.LodIndex].BindResultData(1, simMaterial);
             // assign sea floor depth - to slot 1 current frame data
-            OceanRenderer.Instance.Builder._lodDataAnimWaves[LodTransform.LodIndex].LDSeaDepth.BindResultData(1, simMaterial);
+            OceanRenderer.Instance._lodDataAnimWaves[LodTransform.LodIndex].LDSeaDepth.BindResultData(1, simMaterial);
         }
 
         SimSettingsFoam Settings { get { return _settings as SimSettingsFoam; } }

--- a/src/unity/Assets/Crest/Scripts/LodData/LodDataSeaFloorDepth.cs
+++ b/src/unity/Assets/Crest/Scripts/LodData/LodDataSeaFloorDepth.cs
@@ -25,7 +25,7 @@ namespace Crest
         static Dictionary<Renderer, Material> _depthRenderers = new Dictionary<Renderer, Material>();
         public static void AddRenderOceanDepth(Renderer rend, Material mat)
         {
-            if (OceanRenderer.Instance == null || OceanRenderer.Instance.Builder == null)
+            if (OceanRenderer.Instance == null)
             {
                 _depthRenderers.Clear();
                 return;
@@ -34,14 +34,14 @@ namespace Crest
             _depthRenderers.Add(rend, mat);
 
             // notify there is a new contributor to ocean depth
-            foreach (var ldaw in OceanRenderer.Instance.Builder._lodDataAnimWaves)
+            foreach (var ldaw in OceanRenderer.Instance._lodDataAnimWaves)
             {
                 ldaw.LDSeaDepth._oceanDepthRenderersDirty = true;
             }
         }
         public static void RemoveRenderOceanDepth(Renderer rend)
         {
-            if (OceanRenderer.Instance == null || OceanRenderer.Instance.Builder == null)
+            if (OceanRenderer.Instance == null)
             {
                 _depthRenderers.Clear();
                 return;
@@ -50,7 +50,7 @@ namespace Crest
             _depthRenderers.Remove(rend);
 
             // notify there is a new contributor to ocean depth
-            foreach (var ldaw in OceanRenderer.Instance.Builder._lodDataAnimWaves)
+            foreach (var ldaw in OceanRenderer.Instance._lodDataAnimWaves)
             {
                 ldaw.LDSeaDepth._oceanDepthRenderersDirty = true;
             }

--- a/src/unity/Assets/Crest/Scripts/OceanBuilder.cs
+++ b/src/unity/Assets/Crest/Scripts/OceanBuilder.cs
@@ -11,38 +11,14 @@ namespace Crest
     /// <summary>
     /// Instantiates all the ocean geometry, as a set of tiles.
     /// </summary>
-    public class OceanBuilder : MonoBehaviour
+    public static class OceanBuilder
     {
-        [SerializeField, Tooltip("Material to use for the ocean surface")]
-        Material _oceanMaterial;
-
-        public string _oceanLayerName = "Water";
-        int _oceanLayer = -1;
-
-        [HideInInspector]
-        public LodDataAnimatedWaves[] _lodDataAnimWaves;
-
-        [HideInInspector] public Camera[] _camsAnimWaves;
-        [HideInInspector] public Camera[] _camsFoam;
-        [HideInInspector] public Camera[] _camsFlow;
-        [HideInInspector] public Camera[] _camsDynWaves;
-
-        [Header("Simulations")]
-        public bool _createFoamSim = true;
-        public SimSettingsFoam _simSettingsFoam;
-        public bool _createDynamicWaveSim = false;
-        public SimSettingsWave _simSettingsDynamicWaves;
-        public bool _createFlowSim = false;
-        public SimSettingsFlow _simSettingsFlow;
-
-        public int CurrentLodCount { get { return _camsAnimWaves.Length; } }
-
-        // The comments below illustrate casse when BASE_VERT_DENSITY = 2. The ocean mesh is built up from these patches. Rotational symmetry
+        // The comments below illustrate case when BASE_VERT_DENSITY = 2. The ocean mesh is built up from these patches. Rotational symmetry
         // is used where possible to eliminate combinations. The slim variants are used to eliminate overlap between patches.
         enum PatchType
         {
             /// <summary>
-            /// Adds no skirt. Used in interior of highest detail lod (0)
+            /// Adds no skirt. Used in interior of highest detail LOD (0)
             ///
             ///    1 -------
             ///      |  |  |
@@ -56,7 +32,7 @@ namespace Crest
             Interior,
 
             /// <summary>
-            /// Adds a full skirt all of the way arond a patch
+            /// Adds a full skirt all of the way around a patch
             ///
             ///      -------------
             ///      |  |  |  |  |
@@ -149,27 +125,27 @@ namespace Crest
             Count,
         }
 
-        public void GenerateMesh(float baseVertDensity, int lodCount)
+        public static void GenerateMesh(OceanRenderer ocean, float baseVertDensity, int lodCount)
         {
             if (lodCount < 1)
             {
-                Debug.LogError( "Invalid LOD count: " + lodCount.ToString(), this );
+                Debug.LogError( "Invalid LOD count: " + lodCount.ToString(), ocean );
                 return;
             }
 
 #if UNITY_EDITOR
             if( !UnityEditor.EditorApplication.isPlaying )
             {
-                Debug.LogError( "Ocean mesh meant to be (re)generated in play mode", this );
+                Debug.LogError( "Ocean mesh meant to be (re)generated in play mode", ocean);
                 return;
             }
 #endif
 
-            _oceanLayer = LayerMask.NameToLayer(_oceanLayerName);
-            if (_oceanLayer == -1)
+            int oceanLayer = LayerMask.NameToLayer(ocean.LayerName);
+            if (oceanLayer == -1)
             {
-                Debug.LogError("Invalid ocean layer: " + _oceanLayerName + " please add this layer.", this);
-                _oceanLayer = 0;
+                Debug.LogError("Invalid ocean layer: " + ocean.LayerName + " please add this layer.", ocean);
+                oceanLayer = 0;
             }
 
 #if PROFILE_CONSTRUCTION
@@ -185,51 +161,55 @@ namespace Crest
             }
 
             // create the shape cameras
-            _camsAnimWaves = new Camera[lodCount];
-            _lodDataAnimWaves = new LodDataAnimatedWaves[lodCount];
-            _camsFoam = new Camera[lodCount];
-            _camsFlow = new Camera[lodCount];
-            _camsDynWaves = new Camera[lodCount];
+            ocean._camsAnimWaves = new Camera[lodCount];
+            ocean._lodDataAnimWaves = new LodDataAnimatedWaves[lodCount];
+            ocean._camsFoam = new Camera[lodCount];
+            ocean._camsFlow = new Camera[lodCount];
+            ocean._camsDynWaves = new Camera[lodCount];
 
             var cachedSettings = new Dictionary<System.Type, SimSettingsBase>();
-            if (_simSettingsFoam != null) cachedSettings.Add(typeof(LodDataFoam), _simSettingsFoam);
-            if (_simSettingsFlow != null) cachedSettings.Add(typeof(LodDataFlow), _simSettingsFlow);
-            if (_simSettingsDynamicWaves != null) cachedSettings.Add(typeof(LodDataDynamicWaves), _simSettingsDynamicWaves);
+            if (ocean._simSettingsFoam != null)
+                cachedSettings.Add(typeof(LodDataFoam), ocean._simSettingsFoam);
+            if (ocean._simSettingsFlow != null)
+                cachedSettings.Add(typeof(LodDataFlow), ocean._simSettingsFlow);
+            if (ocean._simSettingsDynamicWaves != null)
+                cachedSettings.Add(typeof(LodDataDynamicWaves), ocean._simSettingsDynamicWaves);
 
             for ( int i = 0; i < lodCount; i++ )
             {
                 {
                     var go = LodData.CreateLodData(i, lodCount, baseVertDensity, LodData.SimType.AnimatedWaves, cachedSettings);
-                    _camsAnimWaves[i] = go.GetComponent<Camera>();
-                    _lodDataAnimWaves[i] = go.GetComponent<LodDataAnimatedWaves>();
+                    ocean._camsAnimWaves[i] = go.GetComponent<Camera>();
+                    ocean._lodDataAnimWaves[i] = go.GetComponent<LodDataAnimatedWaves>();
                 }
 
-                if (_createFoamSim)
+                if (ocean._createFoamSim)
                 {
                     var go = LodData.CreateLodData(i, lodCount, baseVertDensity, LodData.SimType.Foam, cachedSettings);
-                    _camsFoam[i] = go.GetComponent<Camera>();
+                    ocean._camsFoam[i] = go.GetComponent<Camera>();
                 }
 
-                if(_createFlowSim) {
+                if(ocean._createFlowSim)
+                {
                     var go = LodData.CreateLodData(i, lodCount, baseVertDensity, LodData.SimType.Flow, cachedSettings);
-                    _camsFlow[i] = go.GetComponent<Camera>();
+                    ocean._camsFlow[i] = go.GetComponent<Camera>();
                 }
 
-                if (_createDynamicWaveSim)
+                if (ocean._createDynamicWaveSim)
                 {
                     var go = LodData.CreateLodData(i, lodCount, baseVertDensity, LodData.SimType.DynamicWaves, cachedSettings);
-                    _camsDynWaves[i] = go.GetComponent<Camera>();
+                    ocean._camsDynWaves[i] = go.GetComponent<Camera>();
                 }
             }
 
             // remove existing LODs
-            for (int i = 0; i < transform.childCount; i++)
+            for (int i = 0; i < ocean.transform.childCount; i++)
             {
-                var child = transform.GetChild(i);
+                var child = ocean.transform.GetChild(i);
                 if (child.name.StartsWith("LOD"))
                 {
                     child.parent = null;
-                    Destroy(child.gameObject);
+                    Object.Destroy(child.gameObject);
                     i--;
                 }
             }
@@ -238,8 +218,8 @@ namespace Crest
             for( int i = 0; i < lodCount; i++ )
             {
                 bool biggestLOD = i == lodCount - 1;
-                GameObject nextLod = CreateLOD(i, lodCount, biggestLOD, meshInsts, baseVertDensity);
-                nextLod.transform.parent = transform;
+                GameObject nextLod = CreateLOD(ocean, i, lodCount, biggestLOD, meshInsts, baseVertDensity, oceanLayer);
+                nextLod.transform.parent = ocean.transform;
 
                 // scale only horizontally, otherwise culling bounding box will be scaled up in y
                 float horizScale = Mathf.Pow( 2f, (float)(i + startLevel) );
@@ -386,7 +366,7 @@ namespace Crest
             return mesh;
         }
 
-        void PlaceLodData(Transform transform, Transform parent)
+        static void PlaceLodData(Transform transform, Transform parent)
         {
             transform.parent = parent;
             transform.localScale = Vector3.one;
@@ -394,23 +374,26 @@ namespace Crest
             transform.localEulerAngles = Vector3.right * 90f;
         }
 
-        GameObject CreateLOD( int lodIndex, int lodCount, bool biggestLOD, Mesh[] meshData, float baseVertDensity )
+        static GameObject CreateLOD(OceanRenderer ocean, int lodIndex, int lodCount, bool biggestLOD, Mesh[] meshData, float baseVertDensity, int oceanLayer)
         {
             // first create parent gameobject for the lod level. the scale of this transform sets the size of the lod.
             GameObject parent = new GameObject();
             parent.name = "LOD" + lodIndex;
-            parent.layer = _oceanLayer;
-            parent.transform.parent = transform;
+            parent.layer = oceanLayer;
+            parent.transform.parent = ocean.transform;
             parent.transform.localPosition = Vector3.zero;
             parent.transform.localRotation = Quaternion.identity;
 
-            // add lod data cameras into this lod
-            PlaceLodData(_camsAnimWaves[lodIndex].transform, parent.transform);
-            if (_camsFoam[lodIndex] != null) PlaceLodData(_camsFoam[lodIndex].transform, parent.transform);
-            if(_camsFlow[lodIndex] != null) PlaceLodData(_camsFlow[lodIndex].transform, parent.transform);
-            if (_camsDynWaves[lodIndex] != null) PlaceLodData(_camsDynWaves[lodIndex].transform, parent.transform);
+            // add LOD data cameras into this LOD
+            PlaceLodData(ocean._camsAnimWaves[lodIndex].transform, parent.transform);
+            if (ocean._camsFoam[lodIndex] != null)
+                PlaceLodData(ocean._camsFoam[lodIndex].transform, parent.transform);
+            if (ocean._camsFlow[lodIndex] != null)
+                PlaceLodData(ocean._camsFlow[lodIndex].transform, parent.transform);
+            if (ocean._camsDynWaves[lodIndex] != null)
+                PlaceLodData(ocean._camsDynWaves[lodIndex].transform, parent.transform);
 
-            bool generateSkirt = biggestLOD && !OceanRenderer.Instance._disableSkirt;
+            bool generateSkirt = biggestLOD && !ocean._disableSkirt;
 
             Vector2[] offsets;
             PatchType[] patchTypes;
@@ -472,7 +455,7 @@ namespace Crest
 
             // debug toggle to force all patches to be the same. they'll be made with a surrounding skirt to make sure patches
             // overlap
-            if (OceanRenderer.Instance._uniformTiles)
+            if (ocean._uniformTiles)
             {
                 for( int i = 0; i < patchTypes.Length; i++ )
                 {
@@ -485,7 +468,7 @@ namespace Crest
             {
                 // instantiate and place patch
                 var patch = new GameObject( string.Format( "Tile_L{0}", lodIndex ) );
-                patch.layer = _oceanLayer;
+                patch.layer = oceanLayer;
                 patch.transform.parent = parent.transform;
                 Vector2 pos = offsets[i];
                 patch.transform.localPosition = new Vector3( pos.x, 0f, pos.y );
@@ -507,7 +490,7 @@ namespace Crest
                 mr.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off; // arbitrary - could be turned on if desired
                 mr.receiveShadows = false; // arbitrary - could be turned on if desired
                 mr.motionVectorGenerationMode = MotionVectorGenerationMode.ForceNoMotion; // TODO
-                mr.material = _oceanMaterial;
+                mr.material = ocean.OceanMaterial;
 
                 // rotate side patches to point the +x side outwards
                 bool rotateXOutwards = patchTypes[i] == PatchType.FatX || patchTypes[i] == PatchType.FatXOuter || patchTypes[i] == PatchType.SlimX || patchTypes[i] == PatchType.SlimXFatZ;

--- a/src/unity/Assets/Crest/Scripts/OceanChunkRenderer.cs
+++ b/src/unity/Assets/Crest/Scripts/OceanChunkRenderer.cs
@@ -79,17 +79,17 @@ namespace Crest
 
             // assign shape textures to shader
             // this relies on the render textures being init'd in CreateAssignRenderTexture::Awake().
-            var shapeCams = OceanRenderer.Instance.Builder._lodDataAnimWaves;
+            var shapeCams = OceanRenderer.Instance._lodDataAnimWaves;
             shapeCams[_lodIndex].BindResultData(0, _mpb);
             shapeCams[_lodIndex].LDFoam.BindResultData(0, _mpb);
 
-            if(OceanRenderer.Instance.Builder._createFlowSim) shapeCams[_lodIndex].LDFlow.BindResultData(0, _mpb);
+            if(OceanRenderer.Instance._createFlowSim) shapeCams[_lodIndex].LDFlow.BindResultData(0, _mpb);
             shapeCams[_lodIndex].LDSeaDepth.BindResultData(0, _mpb);
             if (_lodIndex + 1 < shapeCams.Length)
             {
                 shapeCams[_lodIndex + 1].BindResultData(1, _mpb);
                 shapeCams[_lodIndex + 1].LDFoam.BindResultData(1, _mpb);
-                if(OceanRenderer.Instance.Builder._createFlowSim) shapeCams[_lodIndex + 1].LDFlow.BindResultData(1, _mpb);
+                if(OceanRenderer.Instance._createFlowSim) shapeCams[_lodIndex + 1].LDFlow.BindResultData(1, _mpb);
                 shapeCams[_lodIndex + 1].LDSeaDepth.BindResultData(1, _mpb);
             }
 

--- a/src/unity/Assets/Crest/Scripts/OceanRenderer.cs
+++ b/src/unity/Assets/Crest/Scripts/OceanRenderer.cs
@@ -12,6 +12,16 @@ namespace Crest
         [Tooltip("The viewpoint which drives the ocean detail. Defaults to main camera.")]
         public Transform _viewpoint;
 
+        [Header("Ocean Params")]
+
+        [SerializeField, Tooltip("Material to use for the ocean surface")]
+        Material _material;
+        public Material OceanMaterial { get { return _material; } }
+
+        [SerializeField]
+        string _layerName = "Water";
+        public string LayerName { get { return _layerName; } }
+
         [Tooltip("Wind direction (angle from x axis in degrees)"), Range(-180, 180)]
         public float _windDirectionAngle = 0f;
         public Vector2 WindDir { get { return new Vector2(Mathf.Cos(Mathf.PI * _windDirectionAngle / 180f), Mathf.Sin(Mathf.PI * _windDirectionAngle / 180f)); } }
@@ -24,6 +34,8 @@ namespace Crest
         bool _cachedCpuOceanQueries = false;
         public bool CachedCpuOceanQueries { get { return _cachedCpuOceanQueries; } }
 
+        [Header("Detail Params")]
+
         [Range(0, 15)]
         [Tooltip("Min number of verts / shape texels per wave.")]
         public float _minTexelsPerWave = 3f;
@@ -34,21 +46,31 @@ namespace Crest
         [Delayed, Tooltip("The largest scale the ocean can be (-1 for unlimited).")]
         public float _maxScale = 128f;
 
-        OceanPlanarReflection _planarReflection;
-        public OceanPlanarReflection PlanarReflection { get { return _planarReflection; } }
-
-        [Header( "Geometry Params" )]
         [SerializeField, Delayed, Tooltip( "Side dimension in quads of an ocean tile." )]
         public float _baseVertDensity = 32f;
+
         [SerializeField, Delayed, Tooltip( "Number of ocean tile scales/LODs to generate." ), ]
         int _lodCount = 6;
         public int LodDataResolution { get { return (int)(4f * _baseVertDensity); } }
 
+        [Header("Simulation Params")]
+
+        public bool _createFoamSim = true;
+        public SimSettingsFoam _simSettingsFoam;
+        public bool _createDynamicWaveSim = false;
+        public SimSettingsWave _simSettingsDynamicWaves;
+        public bool _createFlowSim = false;
+        public SimSettingsFlow _simSettingsFlow;
+
         [Header("Debug Params")]
+
         [Tooltip("Whether to generate ocean geometry tiles uniformly (with overlaps)")]
         public bool _uniformTiles = false;
         [Tooltip("Disable generating a wide strip of triangles at the outer edge to extend ocean to edge of view frustum")]
         public bool _disableSkirt = false;
+
+        OceanPlanarReflection _planarReflection;
+        public OceanPlanarReflection PlanarReflection { get { return _planarReflection; } }
 
         float _viewerAltitudeLevelAlpha = 0f;
         /// <summary>
@@ -61,17 +83,23 @@ namespace Crest
         /// </summary>
         public float SeaLevel { get { return transform.position.y; } }
 
+        [HideInInspector] public LodDataAnimatedWaves[] _lodDataAnimWaves;
+        [HideInInspector] public Camera[] _camsAnimWaves;
+        [HideInInspector] public Camera[] _camsFoam;
+        [HideInInspector] public Camera[] _camsFlow;
+        [HideInInspector] public Camera[] _camsDynWaves;
+        public int CurrentLodCount { get { return _camsAnimWaves.Length; } }
+
         void Start()
         {
             _instance = this;
 
-            _oceanBuilder = FindObjectOfType<OceanBuilder>();
-            _oceanBuilder.GenerateMesh(_baseVertDensity, _lodCount);
+            OceanBuilder.GenerateMesh(this, _baseVertDensity, _lodCount);
 
             // set render orders, event hooks, etc
             var scheduler = GetComponent<IOceanScheduler>();
             if (scheduler == null) scheduler = gameObject.AddComponent<OceanScheduler>();
-            scheduler.ApplySchedule(_oceanBuilder);
+            scheduler.ApplySchedule(this);
 
             InitViewpoint();
         }
@@ -111,7 +139,7 @@ namespace Crest
             LateUpdatePosition();
             LateUpdateScale();
 
-            float maxWavelength = Builder._lodDataAnimWaves[Builder._lodDataAnimWaves.Length - 1].MaxWavelength();
+            float maxWavelength = _lodDataAnimWaves[_lodDataAnimWaves.Length - 1].MaxWavelength();
             Shader.SetGlobalFloat("_MaxWavelength", maxWavelength);
         }
 
@@ -160,7 +188,7 @@ namespace Crest
         [ContextMenu("Regenerate mesh")]
         void RegenMesh()
         {
-            _oceanBuilder.GenerateMesh(_baseVertDensity, _lodCount);
+            OceanBuilder.GenerateMesh(this, _baseVertDensity, _lodCount);
         }
 #if UNITY_EDITOR
         [ContextMenu("Regenerate mesh", true)]
@@ -212,9 +240,6 @@ namespace Crest
 
         static OceanRenderer _instance;
         public static OceanRenderer Instance { get { return _instance ?? (_instance = FindObjectOfType<OceanRenderer>()); } }
-
-        OceanBuilder _oceanBuilder;
-        public OceanBuilder Builder { get { return _oceanBuilder; } }
 
         ICollProvider _collProvider; public ICollProvider CollisionProvider { get { return _collProvider ?? 
                     (_collProvider = _cachedCpuOceanQueries ? new CollProviderCache(_collProvider) as ICollProvider : new CollProviderDispTexs()); } }

--- a/src/unity/Assets/Crest/Scripts/OceanScheduler.cs
+++ b/src/unity/Assets/Crest/Scripts/OceanScheduler.cs
@@ -10,7 +10,7 @@ namespace Crest
     /// </summary>
     public interface IOceanScheduler
     {
-        void ApplySchedule(OceanBuilder ocean);
+        void ApplySchedule(OceanRenderer ocean);
     }
 
     /// <summary>
@@ -21,7 +21,7 @@ namespace Crest
     {
         public bool _warnIfMainCameraDepthLessThan0 = true;
 
-        public virtual void ApplySchedule(OceanBuilder ocean)
+        public virtual void ApplySchedule(OceanRenderer ocean)
         {
             /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
             // --- Dynamic waves camera renders first


### PR DESCRIPTION
@dizzy2003 @Midda-C @moosichu @holdingjason

Hi guys - I've done a refactor that may break existing data and will require fixup, hence this PR.

OceanBuilder had a bit of the key runtime state in it, which led to it being referenced everywhere in the codebase with ugly OceanRenderer.Instance.Builder.XYZW all over the place. This PR moves the state into the OceanRenderer and makes OceanBuilder pure static, which is cleaner and conceptually simpler.

Impact - the OceanBuilder is now a static class instead of a component, and will need to be removed from any gameobjects. Also, the following fields were moved to the OceanRenderer script, and will need to be reconfigured on existing data:

* Ocean material
* Ocean layer name
* Simulation settings - toggles for sims, and the settings fields

This is a nontrivial amount of reconfiguration that may be required. Apologies, I usually try to minimise this kind of impact but it was necessary in this case. Let me know if this will be particularly problematic for you. 
