### PR TITLE
Change uses of ref to other modifiers in functions

### DIFF
--- a/src/unity/Assets/Crest-Examples/BoatDev/Scripts/BoatAlignNormal.cs
+++ b/src/unity/Assets/Crest-Examples/BoatDev/Scripts/BoatAlignNormal.cs
@@ -48,9 +48,9 @@ public class BoatAlignNormal : MonoBehaviour
         var position = transform.position;
 
         Vector3 undispPos;
-        if (!colProvider.ComputeUndisplacedPosition(position, out undispPos)) return;
+        if (!colProvider.ComputeUndisplacedPosition(ref position, out undispPos)) return;
 
-        if (!colProvider.SampleDisplacement(undispPos, out _displacementToBoat)) return;
+        if (!colProvider.SampleDisplacement(ref undispPos, out _displacementToBoat)) return;
         if (!_displacementToBoatInitd)
         {
             _displacementToBoatLastFrame = _displacementToBoat;
@@ -62,7 +62,7 @@ public class BoatAlignNormal : MonoBehaviour
         _displacementToBoatLastFrame = _displacementToBoat;
 
         Vector3 normal;
-        if (!colProvider.SampleNormal(undispPos, out normal, _boatWidth)) return;
+        if (!colProvider.SampleNormal(ref undispPos, out normal, _boatWidth)) return;
         Debug.DrawLine(transform.position, transform.position + 5f * normal);
 
         _velocityRelativeToWater = _rb.velocity - velWater;

--- a/src/unity/Assets/Crest-Examples/BoatDev/Scripts/BoatAlignNormal.cs
+++ b/src/unity/Assets/Crest-Examples/BoatDev/Scripts/BoatAlignNormal.cs
@@ -47,10 +47,10 @@ public class BoatAlignNormal : MonoBehaviour
         var colProvider = OceanRenderer.Instance.CollisionProvider;
         var position = transform.position;
 
-        var undispPos = Vector3.zero;
-        if (!colProvider.ComputeUndisplacedPosition(ref position, ref undispPos)) return;
+        Vector3 undispPos;
+        if (!colProvider.ComputeUndisplacedPosition(position, out undispPos)) return;
 
-        if (!colProvider.SampleDisplacement(ref undispPos, ref _displacementToBoat)) return;
+        if (!colProvider.SampleDisplacement(undispPos, out _displacementToBoat)) return;
         if (!_displacementToBoatInitd)
         {
             _displacementToBoatLastFrame = _displacementToBoat;
@@ -61,8 +61,8 @@ public class BoatAlignNormal : MonoBehaviour
         Vector3 velWater = (_displacementToBoat - _displacementToBoatLastFrame) / Time.deltaTime;
         _displacementToBoatLastFrame = _displacementToBoat;
 
-        var normal = Vector3.zero;
-        if (!colProvider.SampleNormal(ref undispPos, ref normal, _boatWidth)) return;
+        Vector3 normal;
+        if (!colProvider.SampleNormal(undispPos, out normal, _boatWidth)) return;
         Debug.DrawLine(transform.position, transform.position + 5f * normal);
 
         _velocityRelativeToWater = _rb.velocity - velWater;

--- a/src/unity/Assets/Crest-Examples/BoatDev/Scripts/BoatProbes.cs
+++ b/src/unity/Assets/Crest-Examples/BoatDev/Scripts/BoatProbes.cs
@@ -19,8 +19,8 @@ namespace Crest
 
         public void ApplyForceToRB(ShapeGerstnerBatched _waves, Rigidbody _rb)
         {
-            Vector3 undispPos = _waves.GetPositionDisplacedToPosition(ref _position, 0f);
-            Vector3 displacement = _waves.SampleDisplacement(ref undispPos, 0f);
+            Vector3 undispPos = _waves.GetPositionDisplacedToPosition(_position, 0f);
+            Vector3 displacement = _waves.SampleDisplacement(undispPos, 0f);
             float height = OceanRenderer.Instance.SeaLevel + displacement.y;
 
             Vector3 onSeaLevel = _position;
@@ -50,7 +50,7 @@ namespace Crest
             Debug.DrawLine(_position, _position - F * Physics.gravity.normalized, Color.red * 0.5f);
 
             // apply drag relative to water
-            var vel = _waves.GetSurfaceVelocity(ref undispPos, 0f);
+            var vel = _waves.GetSurfaceVelocity(undispPos, 0f);
             var deltaV = _rb.velocity - vel;
             // approximation - interpolate drag based on how submerged the sphere is
             _rb.AddForceAtPosition(-submergedness * _dragInWater * deltaV, Vector3.Lerp(_rb.position, _position, rotAmt));

--- a/src/unity/Assets/Crest-Examples/BoatDev/Scripts/BoatProbes.cs
+++ b/src/unity/Assets/Crest-Examples/BoatDev/Scripts/BoatProbes.cs
@@ -19,8 +19,8 @@ namespace Crest
 
         public void ApplyForceToRB(ShapeGerstnerBatched _waves, Rigidbody _rb)
         {
-            Vector3 undispPos = _waves.GetPositionDisplacedToPosition(_position, 0f);
-            Vector3 displacement = _waves.SampleDisplacement(undispPos, 0f);
+            Vector3 undispPos = _waves.GetPositionDisplacedToPosition(ref _position, 0f);
+            Vector3 displacement = _waves.SampleDisplacement(ref undispPos, 0f);
             float height = OceanRenderer.Instance.SeaLevel + displacement.y;
 
             Vector3 onSeaLevel = _position;
@@ -50,7 +50,7 @@ namespace Crest
             Debug.DrawLine(_position, _position - F * Physics.gravity.normalized, Color.red * 0.5f);
 
             // apply drag relative to water
-            var vel = _waves.GetSurfaceVelocity(undispPos, 0f);
+            var vel = _waves.GetSurfaceVelocity(ref undispPos, 0f);
             var deltaV = _rb.velocity - vel;
             // approximation - interpolate drag based on how submerged the sphere is
             _rb.AddForceAtPosition(-submergedness * _dragInWater * deltaV, Vector3.Lerp(_rb.position, _position, rotAmt));

--- a/src/unity/Assets/Crest-Examples/BoatDev/Scripts/LerpCam.cs
+++ b/src/unity/Assets/Crest-Examples/BoatDev/Scripts/LerpCam.cs
@@ -11,8 +11,8 @@ public class LerpCam : MonoBehaviour
     void Update()
     {
         Vector3 targetPos = _targetPos.position;
-        float h = 0f;
-        if(Crest.OceanRenderer.Instance.CollisionProvider.SampleHeight(ref targetPos, ref h))
+        float h;
+        if(Crest.OceanRenderer.Instance.CollisionProvider.SampleHeight(targetPos, out h))
         {
             targetPos.y = Mathf.Max(targetPos.y, h + _minHeightAboveWater);
         }

--- a/src/unity/Assets/Crest-Examples/BoatDev/Scripts/LerpCam.cs
+++ b/src/unity/Assets/Crest-Examples/BoatDev/Scripts/LerpCam.cs
@@ -12,7 +12,7 @@ public class LerpCam : MonoBehaviour
     {
         Vector3 targetPos = _targetPos.position;
         float h;
-        if(Crest.OceanRenderer.Instance.CollisionProvider.SampleHeight(targetPos, out h))
+        if(Crest.OceanRenderer.Instance.CollisionProvider.SampleHeight(ref targetPos, out h))
         {
             targetPos.y = Mathf.Max(targetPos.y, h + _minHeightAboveWater);
         }

--- a/src/unity/Assets/Crest-Examples/Scripts/Collision/OceanSampleCollisionDemo.cs
+++ b/src/unity/Assets/Crest-Examples/Scripts/Collision/OceanSampleCollisionDemo.cs
@@ -24,7 +24,7 @@ public class OceanSampleCollisionDemo : MonoBehaviour
         query.y = 0f;
 
         Vector3 disp;
-        if (OceanRenderer.Instance.CollisionProvider.SampleDisplacement(query, out disp))
+        if (OceanRenderer.Instance.CollisionProvider.SampleDisplacement(ref query, out disp))
         {
             Debug.DrawLine(query, query + disp);
             marker.transform.position = query + disp;

--- a/src/unity/Assets/Crest-Examples/Scripts/Collision/OceanSampleCollisionDemo.cs
+++ b/src/unity/Assets/Crest-Examples/Scripts/Collision/OceanSampleCollisionDemo.cs
@@ -23,8 +23,8 @@ public class OceanSampleCollisionDemo : MonoBehaviour
 
         query.y = 0f;
 
-        var disp = Vector3.zero;
-        if (OceanRenderer.Instance.CollisionProvider.SampleDisplacement(ref query, ref disp))
+        Vector3 disp;
+        if (OceanRenderer.Instance.CollisionProvider.SampleDisplacement(query, out disp))
         {
             Debug.DrawLine(query, query + disp);
             marker.transform.position = query + disp;

--- a/src/unity/Assets/Crest-Examples/Scripts/Collision/OceanSampleHeightDemo.cs
+++ b/src/unity/Assets/Crest-Examples/Scripts/Collision/OceanSampleHeightDemo.cs
@@ -12,7 +12,7 @@ public class OceanSampleHeightDemo : MonoBehaviour
     {
         var pos = transform.position;
         float height;
-        if (OceanRenderer.Instance.CollisionProvider.SampleHeight(pos, out height))
+        if (OceanRenderer.Instance.CollisionProvider.SampleHeight(ref pos, out height))
         {
             pos.y = height;
             transform.position = pos;

--- a/src/unity/Assets/Crest-Examples/Scripts/Collision/OceanSampleHeightDemo.cs
+++ b/src/unity/Assets/Crest-Examples/Scripts/Collision/OceanSampleHeightDemo.cs
@@ -11,8 +11,8 @@ public class OceanSampleHeightDemo : MonoBehaviour
 	void Update()
     {
         var pos = transform.position;
-        float height = 0f;
-        if (OceanRenderer.Instance.CollisionProvider.SampleHeight(ref pos, ref height))
+        float height;
+        if (OceanRenderer.Instance.CollisionProvider.SampleHeight(pos, out height))
         {
             pos.y = height;
             transform.position = pos;

--- a/src/unity/Assets/Crest/Scripts/Collision/CollProvider.cs
+++ b/src/unity/Assets/Crest/Scripts/Collision/CollProvider.cs
@@ -12,24 +12,24 @@ namespace Crest
         /// <summary>
         /// Samples displacement of ocean surface from the given world position.
         /// </summary>
-        bool SampleDisplacement(Vector3 worldPos, out Vector3 displacement);
-        bool SampleDisplacement(Vector3 worldPos, out Vector3 displacement, float minSpatialLength);
+        bool SampleDisplacement(ref Vector3 in__worldPos, out Vector3 displacement);
+        bool SampleDisplacement(ref Vector3 in__worldPos, out Vector3 displacement, float minSpatialLength);
 
         /// <summary>
         /// Samples ocean surface height at given world position.
         /// </summary>
-        bool SampleHeight(Vector3 worldPos, out float height);
+        bool SampleHeight(ref Vector3 in__worldPos, out float height);
 
         /// <summary>
         /// Sample ocean normal at an undisplaced world position.
         /// </summary>
-        bool SampleNormal(Vector3 undisplacedWorldPos, out Vector3 normal);
-        bool SampleNormal(Vector3 undisplacedWorldPos, out Vector3 normal, float minSpatialLength);
+        bool SampleNormal(ref Vector3 in__undisplacedWorldPos, out Vector3 normal);
+        bool SampleNormal(ref Vector3 in__undisplacedWorldPos, out Vector3 normal, float minSpatialLength);
 
         /// <summary>
         /// Computes the position which will be displaced to the given world position.
         /// </summary>
-        bool ComputeUndisplacedPosition(Vector3 worldPos, out Vector3 undisplacedWorldPos);
+        bool ComputeUndisplacedPosition(ref Vector3 in__worldPos, out Vector3 undisplacedWorldPos);
 
         /// <summary>
         /// Some collision providers benefit from getting prewarmed - call this to set up a sampling area and
@@ -46,10 +46,10 @@ namespace Crest
         /// <summary>
         /// Some collision providers benefit from getting prewarmed - call this after setting up a sampling area.
         /// </summary>
-        bool SampleDisplacementInArea(Vector3 worldPos, out Vector3 displacement);
+        bool SampleDisplacementInArea(ref Vector3 in__worldPos, out Vector3 displacement);
         /// <summary>
         /// Some collision providers benefit from getting prewarmed - call this after setting up a sampling area.
         /// </summary>
-        bool SampleHeightInArea(Vector3 worldPos, out float height);
+        bool SampleHeightInArea(ref Vector3 in__worldPos, out float height);
     }
 }

--- a/src/unity/Assets/Crest/Scripts/Collision/CollProvider.cs
+++ b/src/unity/Assets/Crest/Scripts/Collision/CollProvider.cs
@@ -12,24 +12,24 @@ namespace Crest
         /// <summary>
         /// Samples displacement of ocean surface from the given world position.
         /// </summary>
-        bool SampleDisplacement(ref Vector3 worldPos, ref Vector3 displacement);
-        bool SampleDisplacement(ref Vector3 worldPos, ref Vector3 displacement, float minSpatialLength);
+        bool SampleDisplacement(Vector3 worldPos, out Vector3 displacement);
+        bool SampleDisplacement(Vector3 worldPos, out Vector3 displacement, float minSpatialLength);
 
         /// <summary>
         /// Samples ocean surface height at given world position.
         /// </summary>
-        bool SampleHeight(ref Vector3 worldPos, ref float height);
+        bool SampleHeight(Vector3 worldPos, out float height);
 
         /// <summary>
         /// Sample ocean normal at an undisplaced world position.
         /// </summary>
-        bool SampleNormal(ref Vector3 undisplacedWorldPos, ref Vector3 normal);
-        bool SampleNormal(ref Vector3 undisplacedWorldPos, ref Vector3 normal, float minSpatialLength);
+        bool SampleNormal(Vector3 undisplacedWorldPos, out Vector3 normal);
+        bool SampleNormal(Vector3 undisplacedWorldPos, out Vector3 normal, float minSpatialLength);
 
         /// <summary>
         /// Computes the position which will be displaced to the given world position.
         /// </summary>
-        bool ComputeUndisplacedPosition(ref Vector3 worldPos, ref Vector3 undisplacedWorldPos);
+        bool ComputeUndisplacedPosition(Vector3 worldPos, out Vector3 undisplacedWorldPos);
 
         /// <summary>
         /// Some collision providers benefit from getting prewarmed - call this to set up a sampling area and
@@ -46,10 +46,10 @@ namespace Crest
         /// <summary>
         /// Some collision providers benefit from getting prewarmed - call this after setting up a sampling area.
         /// </summary>
-        bool SampleDisplacementInArea(ref Vector3 worldPos, ref Vector3 displacement);
+        bool SampleDisplacementInArea(Vector3 worldPos, out Vector3 displacement);
         /// <summary>
         /// Some collision providers benefit from getting prewarmed - call this after setting up a sampling area.
         /// </summary>
-        bool SampleHeightInArea(ref Vector3 worldPos, ref float height);
+        bool SampleHeightInArea(Vector3 worldPos, out float height);
     }
 }

--- a/src/unity/Assets/Crest/Scripts/Collision/CollProviderCache.cs
+++ b/src/unity/Assets/Crest/Scripts/Collision/CollProviderCache.cs
@@ -38,26 +38,26 @@ namespace Crest
             _waterHeightCache.Clear();
         }
 
-        uint CalcHash(Vector3 wp)
+        uint CalcHash(ref Vector3 in__wp)
         {
-            int x = (int)(wp.x * _cacheBucketSizeRecip);
-            int z = (int)(wp.z * _cacheBucketSizeRecip);
+            int x = (int)(in__wp.x * _cacheBucketSizeRecip);
+            int z = (int)(in__wp.z * _cacheBucketSizeRecip);
             return (uint)(x + 32768 + ((z + 32768) << 16));
         }
 
         // displacement queries are not cached - only the height computations
-        public bool SampleDisplacement(Vector3 worldPos, out Vector3 displacement)
+        public bool SampleDisplacement(ref Vector3 in__worldPos, out Vector3 displacement)
         {
-            return _collProvider.SampleDisplacement(worldPos, out displacement);
+            return _collProvider.SampleDisplacement(ref in__worldPos, out displacement);
         }
-        public bool SampleDisplacement(Vector3 worldPos, out Vector3 displacement, float minSpatialLength)
+        public bool SampleDisplacement(ref Vector3 in__worldPos, out Vector3 displacement, float minSpatialLength)
         {
-            return _collProvider.SampleDisplacement(worldPos, out displacement, minSpatialLength);
+            return _collProvider.SampleDisplacement(ref in__worldPos, out displacement, minSpatialLength);
         }
 
-        public bool SampleHeight(Vector3 worldPos, out float height)
+        public bool SampleHeight(ref Vector3 in__worldPos, out float height)
         {
-            var hash = CalcHash(worldPos);
+            var hash = CalcHash(ref in__worldPos);
 
             _cacheChecks++;
             if (_waterHeightCache.TryGetValue(hash, out height))
@@ -68,7 +68,7 @@ namespace Crest
             }
 
             // compute the height
-            bool success = _collProvider.SampleHeight(worldPos, out height);
+            bool success = _collProvider.SampleHeight(ref in__worldPos, out height);
 
             // populate cache (regardless of success for now)
             _waterHeightCache.Add(hash, height);
@@ -84,27 +84,27 @@ namespace Crest
         {
             // nothing to do here
         }
-        public bool SampleDisplacementInArea(Vector3 worldPos, out Vector3 displacement)
+        public bool SampleDisplacementInArea(ref Vector3 in__worldPos, out Vector3 displacement)
         {
-            return _collProvider.SampleDisplacement(worldPos, out displacement);
+            return _collProvider.SampleDisplacement(ref in__worldPos, out displacement);
         }
-        public bool SampleHeightInArea(Vector3 worldPos, out float height)
+        public bool SampleHeightInArea(ref Vector3 in__worldPos, out float height)
         {
-            return SampleHeight(worldPos, out height);
-        }
-
-        public bool SampleNormal(Vector3 undisplacedWorldPos, out Vector3 normal)
-        {
-            return _collProvider.SampleNormal(undisplacedWorldPos, out normal);
-        }
-        public bool SampleNormal(Vector3 undisplacedWorldPos, out Vector3 normal, float minSpatialLength)
-        {
-            return _collProvider.SampleNormal(undisplacedWorldPos, out normal, minSpatialLength);
+            return SampleHeight(ref in__worldPos, out height);
         }
 
-        public bool ComputeUndisplacedPosition(Vector3 worldPos, out Vector3 undisplacedWorldPos)
+        public bool SampleNormal(ref Vector3 in__undisplacedWorldPos, out Vector3 normal)
         {
-            return _collProvider.ComputeUndisplacedPosition(worldPos, out undisplacedWorldPos);
+            return _collProvider.SampleNormal(ref in__undisplacedWorldPos, out normal);
+        }
+        public bool SampleNormal(ref Vector3 in__undisplacedWorldPos, out Vector3 normal, float minSpatialLength)
+        {
+            return _collProvider.SampleNormal(ref in__undisplacedWorldPos, out normal, minSpatialLength);
+        }
+
+        public bool ComputeUndisplacedPosition(ref Vector3 in__worldPos, out Vector3 undisplacedWorldPos)
+        {
+            return _collProvider.ComputeUndisplacedPosition(ref in__worldPos, out undisplacedWorldPos);
         }
 
         public int CacheChecks { get { return _cacheChecksLastFrame; } }

--- a/src/unity/Assets/Crest/Scripts/Collision/CollProviderCache.cs
+++ b/src/unity/Assets/Crest/Scripts/Collision/CollProviderCache.cs
@@ -38,7 +38,7 @@ namespace Crest
             _waterHeightCache.Clear();
         }
 
-        uint CalcHash(ref Vector3 wp)
+        uint CalcHash(Vector3 wp)
         {
             int x = (int)(wp.x * _cacheBucketSizeRecip);
             int z = (int)(wp.z * _cacheBucketSizeRecip);
@@ -46,18 +46,18 @@ namespace Crest
         }
 
         // displacement queries are not cached - only the height computations
-        public bool SampleDisplacement(ref Vector3 worldPos, ref Vector3 displacement)
+        public bool SampleDisplacement(Vector3 worldPos, out Vector3 displacement)
         {
-            return _collProvider.SampleDisplacement(ref worldPos, ref displacement);
+            return _collProvider.SampleDisplacement(worldPos, out displacement);
         }
-        public bool SampleDisplacement(ref Vector3 worldPos, ref Vector3 displacement, float minSpatialLength)
+        public bool SampleDisplacement(Vector3 worldPos, out Vector3 displacement, float minSpatialLength)
         {
-            return _collProvider.SampleDisplacement(ref worldPos, ref displacement, minSpatialLength);
+            return _collProvider.SampleDisplacement(worldPos, out displacement, minSpatialLength);
         }
 
-        public bool SampleHeight(ref Vector3 worldPos, ref float height)
+        public bool SampleHeight(Vector3 worldPos, out float height)
         {
-            var hash = CalcHash(ref worldPos);
+            var hash = CalcHash(worldPos);
 
             _cacheChecks++;
             if (_waterHeightCache.TryGetValue(hash, out height))
@@ -68,7 +68,7 @@ namespace Crest
             }
 
             // compute the height
-            bool success = _collProvider.SampleHeight(ref worldPos, ref height);
+            bool success = _collProvider.SampleHeight(worldPos, out height);
 
             // populate cache (regardless of success for now)
             _waterHeightCache.Add(hash, height);
@@ -84,27 +84,27 @@ namespace Crest
         {
             // nothing to do here
         }
-        public bool SampleDisplacementInArea(ref Vector3 worldPos, ref Vector3 displacement)
+        public bool SampleDisplacementInArea(Vector3 worldPos, out Vector3 displacement)
         {
-            return _collProvider.SampleDisplacement(ref worldPos, ref displacement);
+            return _collProvider.SampleDisplacement(worldPos, out displacement);
         }
-        public bool SampleHeightInArea(ref Vector3 worldPos, ref float height)
+        public bool SampleHeightInArea(Vector3 worldPos, out float height)
         {
-            return SampleHeight(ref worldPos, ref height);
-        }
-
-        public bool SampleNormal(ref Vector3 undisplacedWorldPos, ref Vector3 normal)
-        {
-            return _collProvider.SampleNormal(ref undisplacedWorldPos, ref normal);
-        }
-        public bool SampleNormal(ref Vector3 undisplacedWorldPos, ref Vector3 normal, float minSpatialLength)
-        {
-            return _collProvider.SampleNormal(ref undisplacedWorldPos, ref normal, minSpatialLength);
+            return SampleHeight(worldPos, out height);
         }
 
-        public bool ComputeUndisplacedPosition(ref Vector3 worldPos, ref Vector3 undisplacedWorldPos)
+        public bool SampleNormal(Vector3 undisplacedWorldPos, out Vector3 normal)
         {
-            return _collProvider.ComputeUndisplacedPosition(ref worldPos, ref undisplacedWorldPos);
+            return _collProvider.SampleNormal(undisplacedWorldPos, out normal);
+        }
+        public bool SampleNormal(Vector3 undisplacedWorldPos, out Vector3 normal, float minSpatialLength)
+        {
+            return _collProvider.SampleNormal(undisplacedWorldPos, out normal, minSpatialLength);
+        }
+
+        public bool ComputeUndisplacedPosition(Vector3 worldPos, out Vector3 undisplacedWorldPos)
+        {
+            return _collProvider.ComputeUndisplacedPosition(worldPos, out undisplacedWorldPos);
         }
 
         public int CacheChecks { get { return _cacheChecksLastFrame; } }

--- a/src/unity/Assets/Crest/Scripts/Collision/CollProviderDispTexs.cs
+++ b/src/unity/Assets/Crest/Scripts/Collision/CollProviderDispTexs.cs
@@ -17,7 +17,7 @@ namespace Crest
         {
             int lod = LodDataAnimatedWaves.SuggestDataLOD(new Rect(in__worldPos.x, in__worldPos.z, 0f, 0f), 0f);
             if (lod == -1) {
-                displacement = Vector2.zero;
+                displacement = Vector3.zero;
                 return false;
             }
             return OceanRenderer.Instance._lodDataAnimWaves[lod].SampleDisplacement(ref in__worldPos, out displacement);
@@ -34,7 +34,7 @@ namespace Crest
         {
             int lod = LodDataAnimatedWaves.SuggestDataLOD(new Rect(in__worldPos.x, in__worldPos.z, 0f, 0f), 0f);
             if (lod == -1) {
-                height = float.NaN;
+                height = 0;
                 return false;
             }
             height = OceanRenderer.Instance._lodDataAnimWaves[lod].GetHeight(ref in__worldPos);

--- a/src/unity/Assets/Crest/Scripts/Collision/CollProviderDispTexs.cs
+++ b/src/unity/Assets/Crest/Scripts/Collision/CollProviderDispTexs.cs
@@ -13,31 +13,31 @@ namespace Crest
     {
         int _areaLod = -1;
 
-        public bool SampleDisplacement(Vector3 worldPos, out Vector3 displacement)
+        public bool SampleDisplacement(ref Vector3 in__worldPos, out Vector3 displacement)
         {
-            int lod = LodDataAnimatedWaves.SuggestDataLOD(new Rect(worldPos.x, worldPos.z, 0f, 0f), 0f);
+            int lod = LodDataAnimatedWaves.SuggestDataLOD(new Rect(in__worldPos.x, in__worldPos.z, 0f, 0f), 0f);
             if (lod == -1) {
                 displacement = Vector2.zero;
                 return false;
             }
-            return OceanRenderer.Instance._lodDataAnimWaves[lod].SampleDisplacement(worldPos, out displacement);
+            return OceanRenderer.Instance._lodDataAnimWaves[lod].SampleDisplacement(ref in__worldPos, out displacement);
         }
-        public bool SampleDisplacement(Vector3 worldPos, out Vector3 displacement, float minSpatialLength)
+        public bool SampleDisplacement(ref Vector3 in__worldPos, out Vector3 displacement, float minSpatialLength)
         {
             // select lod. this now has a 1 texel buffer, so the finite differences below should all be valid.
-            PrewarmForSamplingArea(new Rect(worldPos.x, worldPos.z, 0f, 0f), minSpatialLength);
+            PrewarmForSamplingArea(new Rect(in__worldPos.x, in__worldPos.z, 0f, 0f), minSpatialLength);
 
-            return SampleDisplacementInArea(worldPos, out displacement);
+            return SampleDisplacementInArea(ref in__worldPos, out displacement);
         }
 
-        public bool SampleHeight(Vector3 worldPos, out float height)
+        public bool SampleHeight(ref Vector3 in__worldPos, out float height)
         {
-            int lod = LodDataAnimatedWaves.SuggestDataLOD(new Rect(worldPos.x, worldPos.z, 0f, 0f), 0f);
+            int lod = LodDataAnimatedWaves.SuggestDataLOD(new Rect(in__worldPos.x, in__worldPos.z, 0f, 0f), 0f);
             if (lod == -1) {
                 height = float.NaN;
                 return false;
             }
-            height = OceanRenderer.Instance._lodDataAnimWaves[lod].GetHeight(worldPos);
+            height = OceanRenderer.Instance._lodDataAnimWaves[lod].GetHeight(ref in__worldPos);
             return true;
         }
 
@@ -49,53 +49,53 @@ namespace Crest
         {
             _areaLod = LodDataAnimatedWaves.SuggestDataLOD(areaXZ, minSpatialLength);
         }
-        public bool SampleDisplacementInArea(Vector3 worldPos, out Vector3 displacement)
+        public bool SampleDisplacementInArea(ref Vector3 in__worldPos, out Vector3 displacement)
         {
-            return OceanRenderer.Instance._lodDataAnimWaves[_areaLod].SampleDisplacement(worldPos, out displacement);
+            return OceanRenderer.Instance._lodDataAnimWaves[_areaLod].SampleDisplacement(ref in__worldPos, out displacement);
         }
-        public bool SampleHeightInArea(Vector3 worldPos, out float height)
+        public bool SampleHeightInArea(ref Vector3 in__worldPos, out float height)
         {
-            height = OceanRenderer.Instance._lodDataAnimWaves[_areaLod].GetHeight(worldPos);
+            height = OceanRenderer.Instance._lodDataAnimWaves[_areaLod].GetHeight(ref in__worldPos);
             return true;
         }
 
-        public bool SampleNormal(Vector3 undisplacedWorldPos, out Vector3 normal)
+        public bool SampleNormal(ref Vector3 in__undisplacedWorldPos, out Vector3 normal)
         {
-            return SampleNormal(undisplacedWorldPos, out normal, 0f);
+            return SampleNormal(ref in__undisplacedWorldPos, out normal, 0f);
         }
-        public bool SampleNormal(Vector3 undisplacedWorldPos, out Vector3 normal, float minSpatialLength)
+        public bool SampleNormal(ref Vector3 in__undisplacedWorldPos, out Vector3 normal, float minSpatialLength)
         {
             // select lod. this now has a 1 texel buffer, so the finite differences below should all be valid.
-            PrewarmForSamplingArea(new Rect(undisplacedWorldPos.x, undisplacedWorldPos.z, 0f, 0f), minSpatialLength);
+            PrewarmForSamplingArea(new Rect(in__undisplacedWorldPos.x, in__undisplacedWorldPos.z, 0f, 0f), minSpatialLength);
 
             float gridSize = OceanRenderer.Instance._lodDataAnimWaves[_areaLod].LodTransform._renderData._texelWidth;
             normal = Vector3.zero;
             Vector3 dispCenter = Vector3.zero;
-            if (!SampleDisplacementInArea(undisplacedWorldPos, out dispCenter)) return false;
-            Vector3 undisplacedWorldPosX = undisplacedWorldPos + Vector3.right * gridSize;
+            if (!SampleDisplacementInArea(ref in__undisplacedWorldPos, out dispCenter)) return false;
+            Vector3 undisplacedWorldPosX = in__undisplacedWorldPos + Vector3.right * gridSize;
             Vector3 dispX = Vector3.zero;
-            if (!SampleDisplacementInArea(undisplacedWorldPosX, out dispX)) return false;
-            Vector3 undisplacedWorldPosZ = undisplacedWorldPos + Vector3.forward * gridSize;
+            if (!SampleDisplacementInArea(ref undisplacedWorldPosX, out dispX)) return false;
+            Vector3 undisplacedWorldPosZ = in__undisplacedWorldPos + Vector3.forward * gridSize;
             Vector3 dispZ = Vector3.zero;
-            if (!SampleDisplacementInArea(undisplacedWorldPosZ, out dispZ)) return false;
+            if (!SampleDisplacementInArea(ref undisplacedWorldPosZ, out dispZ)) return false;
 
             normal = Vector3.Cross(dispZ + Vector3.forward * gridSize - dispCenter, dispX + Vector3.right * gridSize - dispCenter).normalized;
 
             return true;
         }
 
-        public bool ComputeUndisplacedPosition(Vector3 worldPos, out Vector3 undisplacedWorldPos)
+        public bool ComputeUndisplacedPosition(ref Vector3 in__worldPos, out Vector3 undisplacedWorldPos)
         {
             // fpi - guess should converge to location that displaces to the target position
-            Vector3 guess = worldPos;
+            Vector3 guess = in__worldPos;
             // 2 iterations was enough to get very close when chop = 1, added 2 more which should be
             // sufficient for most applications. for high chop values or really stormy conditions there may
             // be some error here. one could also terminate iteration based on the size of the error, this is
             // worth trying but is left as future work for now.
             Vector3 disp = Vector3.zero;
-            for (int i = 0; i < 4 && SampleDisplacement(guess, out disp); i++)
+            for (int i = 0; i < 4 && SampleDisplacement(ref guess, out disp); i++)
             {
-                Vector3 error = guess + disp - worldPos;
+                Vector3 error = guess + disp - in__worldPos;
                 guess.x -= error.x;
                 guess.z -= error.z;
             }

--- a/src/unity/Assets/Crest/Scripts/Collision/CollProviderDispTexs.cs
+++ b/src/unity/Assets/Crest/Scripts/Collision/CollProviderDispTexs.cs
@@ -13,25 +13,31 @@ namespace Crest
     {
         int _areaLod = -1;
 
-        public bool SampleDisplacement(ref Vector3 worldPos, ref Vector3 displacement)
+        public bool SampleDisplacement(Vector3 worldPos, out Vector3 displacement)
         {
             int lod = LodDataAnimatedWaves.SuggestDataLOD(new Rect(worldPos.x, worldPos.z, 0f, 0f), 0f);
-            if (lod == -1) return false;
-            return OceanRenderer.Instance._lodDataAnimWaves[lod].SampleDisplacement(ref worldPos, ref displacement);
+            if (lod == -1) {
+                displacement = Vector2.zero;
+                return false;
+            }
+            return OceanRenderer.Instance._lodDataAnimWaves[lod].SampleDisplacement(worldPos, out displacement);
         }
-        public bool SampleDisplacement(ref Vector3 worldPos, ref Vector3 displacement, float minSpatialLength)
+        public bool SampleDisplacement(Vector3 worldPos, out Vector3 displacement, float minSpatialLength)
         {
             // select lod. this now has a 1 texel buffer, so the finite differences below should all be valid.
             PrewarmForSamplingArea(new Rect(worldPos.x, worldPos.z, 0f, 0f), minSpatialLength);
 
-            return SampleDisplacementInArea(ref worldPos, ref displacement);
+            return SampleDisplacementInArea(worldPos, out displacement);
         }
 
-        public bool SampleHeight(ref Vector3 worldPos, ref float height)
+        public bool SampleHeight(Vector3 worldPos, out float height)
         {
             int lod = LodDataAnimatedWaves.SuggestDataLOD(new Rect(worldPos.x, worldPos.z, 0f, 0f), 0f);
-            if (lod == -1) return false;
-            height = OceanRenderer.Instance._lodDataAnimWaves[lod].GetHeight(ref worldPos);
+            if (lod == -1) {
+                height = float.NaN;
+                return false;
+            }
+            height = OceanRenderer.Instance._lodDataAnimWaves[lod].GetHeight(worldPos);
             return true;
         }
 
@@ -43,42 +49,42 @@ namespace Crest
         {
             _areaLod = LodDataAnimatedWaves.SuggestDataLOD(areaXZ, minSpatialLength);
         }
-        public bool SampleDisplacementInArea(ref Vector3 worldPos, ref Vector3 displacement)
+        public bool SampleDisplacementInArea(Vector3 worldPos, out Vector3 displacement)
         {
-            return OceanRenderer.Instance._lodDataAnimWaves[_areaLod].SampleDisplacement(ref worldPos, ref displacement);
+            return OceanRenderer.Instance._lodDataAnimWaves[_areaLod].SampleDisplacement(worldPos, out displacement);
         }
-        public bool SampleHeightInArea(ref Vector3 worldPos, ref float height)
+        public bool SampleHeightInArea(Vector3 worldPos, out float height)
         {
-            height = OceanRenderer.Instance._lodDataAnimWaves[_areaLod].GetHeight(ref worldPos);
+            height = OceanRenderer.Instance._lodDataAnimWaves[_areaLod].GetHeight(worldPos);
             return true;
         }
 
-        public bool SampleNormal(ref Vector3 undisplacedWorldPos, ref Vector3 normal)
+        public bool SampleNormal(Vector3 undisplacedWorldPos, out Vector3 normal)
         {
-            return SampleNormal(ref undisplacedWorldPos, ref normal, 0f);
+            return SampleNormal(undisplacedWorldPos, out normal, 0f);
         }
-        public bool SampleNormal(ref Vector3 undisplacedWorldPos, ref Vector3 normal, float minSpatialLength)
+        public bool SampleNormal(Vector3 undisplacedWorldPos, out Vector3 normal, float minSpatialLength)
         {
             // select lod. this now has a 1 texel buffer, so the finite differences below should all be valid.
             PrewarmForSamplingArea(new Rect(undisplacedWorldPos.x, undisplacedWorldPos.z, 0f, 0f), minSpatialLength);
 
             float gridSize = OceanRenderer.Instance._lodDataAnimWaves[_areaLod].LodTransform._renderData._texelWidth;
-
+            normal = Vector3.zero;
             Vector3 dispCenter = Vector3.zero;
-            if (!SampleDisplacementInArea(ref undisplacedWorldPos, ref dispCenter)) return false;
+            if (!SampleDisplacementInArea(undisplacedWorldPos, out dispCenter)) return false;
             Vector3 undisplacedWorldPosX = undisplacedWorldPos + Vector3.right * gridSize;
             Vector3 dispX = Vector3.zero;
-            if (!SampleDisplacementInArea(ref undisplacedWorldPosX, ref dispX)) return false;
+            if (!SampleDisplacementInArea(undisplacedWorldPosX, out dispX)) return false;
             Vector3 undisplacedWorldPosZ = undisplacedWorldPos + Vector3.forward * gridSize;
             Vector3 dispZ = Vector3.zero;
-            if (!SampleDisplacementInArea(ref undisplacedWorldPosZ, ref dispZ)) return false;
+            if (!SampleDisplacementInArea(undisplacedWorldPosZ, out dispZ)) return false;
 
             normal = Vector3.Cross(dispZ + Vector3.forward * gridSize - dispCenter, dispX + Vector3.right * gridSize - dispCenter).normalized;
 
             return true;
         }
 
-        public bool ComputeUndisplacedPosition(ref Vector3 worldPos, ref Vector3 undisplacedWorldPos)
+        public bool ComputeUndisplacedPosition(Vector3 worldPos, out Vector3 undisplacedWorldPos)
         {
             // fpi - guess should converge to location that displaces to the target position
             Vector3 guess = worldPos;
@@ -87,7 +93,7 @@ namespace Crest
             // be some error here. one could also terminate iteration based on the size of the error, this is
             // worth trying but is left as future work for now.
             Vector3 disp = Vector3.zero;
-            for (int i = 0; i < 4 && SampleDisplacement(ref guess, ref disp); i++)
+            for (int i = 0; i < 4 && SampleDisplacement(guess, out disp); i++)
             {
                 Vector3 error = guess + disp - worldPos;
                 guess.x -= error.x;

--- a/src/unity/Assets/Crest/Scripts/LodData/LodDataAnimatedWaves.cs
+++ b/src/unity/Assets/Crest/Scripts/LodData/LodDataAnimatedWaves.cs
@@ -149,10 +149,10 @@ namespace Crest
                 new Vector4(LodTransform._renderData._texelWidth, LodTransform._renderData._textureRes, shapeWeight, 1f / LodTransform._renderData._textureRes));
         }
 
-        public bool SampleDisplacement(Vector3 worldPos, out Vector3 displacement)
+        public bool SampleDisplacement(ref Vector3 in__worldPos, out Vector3 displacement)
         {
-            float xOffset = worldPos.x - _dataReadback._dataRenderData._posSnapped.x;
-            float zOffset = worldPos.z - _dataReadback._dataRenderData._posSnapped.z;
+            float xOffset = in__worldPos.x - _dataReadback._dataRenderData._posSnapped.x;
+            float zOffset = in__worldPos.z - _dataReadback._dataRenderData._posSnapped.z;
             float r = _dataReadback._dataRenderData._texelWidth * _dataReadback._dataRenderData._textureRes / 2f;
             if (Mathf.Abs(xOffset) >= r || Mathf.Abs(zOffset) >= r)
             {
@@ -177,11 +177,11 @@ namespace Crest
         /// <summary>
         /// Get position on ocean plane that displaces horizontally to the given position.
         /// </summary>
-        public Vector3 GetPositionDisplacedToPosition(Vector3 displacedWorldPos)
+        public Vector3 GetPositionDisplacedToPosition(ref Vector3 in__displacedWorldPos)
         {
             // fixed point iteration - guess should converge to location that displaces to the target position
 
-            var guess = displacedWorldPos;
+            var guess = in__displacedWorldPos;
 
             // 2 iterations was enough to get very close when chop = 1, added 2 more which should be
             // sufficient for most applications. for high chop values or really stormy conditions there may
@@ -190,8 +190,8 @@ namespace Crest
             for (int i = 0; i < 4; i++)
             {
                 var disp = Vector3.zero;
-                SampleDisplacement(guess, out disp);
-                var error = guess + disp - displacedWorldPos;
+                SampleDisplacement(ref guess, out disp);
+                var error = guess + disp - in__displacedWorldPos;
                 guess.x -= error.x;
                 guess.z -= error.z;
             }
@@ -199,15 +199,15 @@ namespace Crest
             return guess;
         }
 
-        public float GetHeight(Vector3 worldPos)
+        public float GetHeight(ref Vector3 in__worldPos)
         {
-            var posFlatland = worldPos;
+            var posFlatland = in__worldPos;
             posFlatland.y = OceanRenderer.Instance.transform.position.y;
 
-            var undisplacedPos = GetPositionDisplacedToPosition(posFlatland);
+            var undisplacedPos = GetPositionDisplacedToPosition(ref posFlatland);
 
             var disp = Vector3.zero;
-            SampleDisplacement(undisplacedPos, out disp);
+            SampleDisplacement(ref undisplacedPos, out disp);
 
             return posFlatland.y + disp.y;
         }

--- a/src/unity/Assets/Crest/Scripts/LodData/LodDataAnimatedWaves.cs
+++ b/src/unity/Assets/Crest/Scripts/LodData/LodDataAnimatedWaves.cs
@@ -8,7 +8,7 @@ namespace Crest
     /// <summary>
     /// Captures waves/shape that is drawn kinematically - there is no frame-to-frame state. The gerstner
     /// waves are drawn in this way. There are two special features of this particular LodData.
-    /// 
+    ///
     ///  * A combine pass is done which combines downwards from low detail lods down into the high detail lods (see OceanScheduler).
     ///  * The textures from this LodData are passed to the ocean material when the surface is drawn (by OceanChunkRenderer).
     ///  * LodDataDynamicWaves adds its results into this LodData. The dynamic waves piggy back off the combine
@@ -145,11 +145,11 @@ namespace Crest
             // need to blend out shape if this is the largest lod, and the ocean might get scaled down later (so the largest lod will disappear)
             bool needToBlendOutShape = LodTransform.LodIndex == LodTransform.LodCount - 1 && OceanRenderer.Instance.ScaleCouldDecrease && blendOut;
             float shapeWeight = needToBlendOutShape ? OceanRenderer.Instance.ViewerAltitudeLevelAlpha : 1f;
-            properties.SetVector(_paramsOceanParams[shapeSlot], 
+            properties.SetVector(_paramsOceanParams[shapeSlot],
                 new Vector4(LodTransform._renderData._texelWidth, LodTransform._renderData._textureRes, shapeWeight, 1f / LodTransform._renderData._textureRes));
         }
 
-        public bool SampleDisplacement(ref Vector3 worldPos, ref Vector3 displacement)
+        public bool SampleDisplacement(Vector3 worldPos, out Vector3 displacement)
         {
             float xOffset = worldPos.x - _dataReadback._dataRenderData._posSnapped.x;
             float zOffset = worldPos.z - _dataReadback._dataRenderData._posSnapped.z;
@@ -157,6 +157,7 @@ namespace Crest
             if (Mathf.Abs(xOffset) >= r || Mathf.Abs(zOffset) >= r)
             {
                 // outside of this collision data
+                displacement = Vector2.zero;
                 return false;
             }
 
@@ -176,7 +177,7 @@ namespace Crest
         /// <summary>
         /// Get position on ocean plane that displaces horizontally to the given position.
         /// </summary>
-        public Vector3 GetPositionDisplacedToPosition(ref Vector3 displacedWorldPos)
+        public Vector3 GetPositionDisplacedToPosition(Vector3 displacedWorldPos)
         {
             // fixed point iteration - guess should converge to location that displaces to the target position
 
@@ -189,7 +190,7 @@ namespace Crest
             for (int i = 0; i < 4; i++)
             {
                 var disp = Vector3.zero;
-                SampleDisplacement(ref guess, ref disp);
+                SampleDisplacement(guess, out disp);
                 var error = guess + disp - displacedWorldPos;
                 guess.x -= error.x;
                 guess.z -= error.z;
@@ -198,15 +199,15 @@ namespace Crest
             return guess;
         }
 
-        public float GetHeight(ref Vector3 worldPos)
+        public float GetHeight(Vector3 worldPos)
         {
             var posFlatland = worldPos;
             posFlatland.y = OceanRenderer.Instance.transform.position.y;
 
-            var undisplacedPos = GetPositionDisplacedToPosition(ref posFlatland);
+            var undisplacedPos = GetPositionDisplacedToPosition(posFlatland);
 
             var disp = Vector3.zero;
-            SampleDisplacement(ref undisplacedPos, ref disp);
+            SampleDisplacement(undisplacedPos, out disp);
 
             return posFlatland.y + disp.y;
         }

--- a/src/unity/Assets/Crest/Scripts/LodData/LodDataAnimatedWaves.cs
+++ b/src/unity/Assets/Crest/Scripts/LodData/LodDataAnimatedWaves.cs
@@ -157,7 +157,7 @@ namespace Crest
             if (Mathf.Abs(xOffset) >= r || Mathf.Abs(zOffset) >= r)
             {
                 // outside of this collision data
-                displacement = Vector2.zero;
+                displacement = Vector3.zero;
                 return false;
             }
 

--- a/src/unity/Assets/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/src/unity/Assets/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -169,7 +169,7 @@ namespace Crest
                         int ei = numInBatch - vi * 4;
                         UpdateBatchScratchData._wavelengthsBatch[vi][ei] = wl;
                         UpdateBatchScratchData._ampsBatch[vi][ei] = amp;
-                        UpdateBatchScratchData._anglesBatch[vi][ei] = 
+                        UpdateBatchScratchData._anglesBatch[vi][ei] =
                             Mathf.Deg2Rad * (OceanRenderer.Instance._windDirectionAngle + _angleDegs[firstComponent + i]);
                         UpdateBatchScratchData._phasesBatch[vi][ei] = _phases[firstComponent + i];
                         UpdateBatchScratchData._chopScalesBatch[vi][ei] = _spectrum._chopScales[(firstComponent + i) / _componentsPerOctave];
@@ -374,7 +374,7 @@ namespace Crest
             return cp;
         }
 
-        public Vector3 GetPositionDisplacedToPosition(ref Vector3 displacedWorldPos, float toff)
+        public Vector3 GetPositionDisplacedToPosition(Vector3 displacedWorldPos, float toff)
         {
             // fpi - guess should converge to location that displaces to the target position
             Vector3 guess = displacedWorldPos;
@@ -384,7 +384,7 @@ namespace Crest
             // worth trying but is left as future work for now.
             for (int i = 0; i < 4; i++)
             {
-                Vector3 error = guess + SampleDisplacement(ref guess, toff) - displacedWorldPos;
+                Vector3 error = guess + SampleDisplacement(guess, toff) - displacedWorldPos;
                 guess.x -= error.x;
                 guess.z -= error.z;
             }
@@ -394,7 +394,7 @@ namespace Crest
             return guess;
         }
 
-        public Vector3 SampleDisplacement(ref Vector3 worldPos, float toff)
+        public Vector3 SampleDisplacement(Vector3 worldPos, float toff)
         {
             if (_amplitudes == null) return Vector3.zero;
 
@@ -429,7 +429,7 @@ namespace Crest
         }
 
         // compute normal to a surface with a parameterization - equation 14 here: http://mathworld.wolfram.com/NormalVector.html
-        public Vector3 GetNormal(ref Vector3 worldPos, float toff)
+        public Vector3 GetNormal(Vector3 worldPos, float toff)
         {
             if (_amplitudes == null) return Vector3.zero;
 
@@ -466,17 +466,17 @@ namespace Crest
             return Vector3.Cross(delfdelz, delfdelx).normalized;
         }
 
-        public float SampleHeight(ref Vector3 worldPos, float toff)
+        public float SampleHeight(Vector3 worldPos, float toff)
         {
             Vector3 posFlatland = worldPos;
             posFlatland.y = OceanRenderer.Instance.transform.position.y;
 
-            Vector3 undisplacedPos = GetPositionDisplacedToPosition(ref posFlatland, toff);
+            Vector3 undisplacedPos = GetPositionDisplacedToPosition(posFlatland, toff);
 
-            return posFlatland.y + SampleDisplacement(ref undisplacedPos, toff).y;
+            return posFlatland.y + SampleDisplacement(undisplacedPos, toff).y;
         }
 
-        public Vector3 GetSurfaceVelocity(ref Vector3 worldPos, float toff)
+        public Vector3 GetSurfaceVelocity(Vector3 worldPos, float toff)
         {
             if (_amplitudes == null) return Vector3.zero;
 
@@ -510,20 +510,20 @@ namespace Crest
             return result;
         }
 
-        public bool SampleDisplacement(ref Vector3 worldPos, ref Vector3 displacement)
+        public bool SampleDisplacement(Vector3 worldPos, out Vector3 displacement)
         {
-            displacement = SampleDisplacement(ref worldPos, 0f);
+            displacement = SampleDisplacement(worldPos, 0f);
             return true;
         }
 
-        public bool SampleDisplacement(ref Vector3 worldPos, ref Vector3 displacement, float minSpatialLength)
+        public bool SampleDisplacement(Vector3 worldPos, out Vector3 displacement, float minSpatialLength)
         {
-            return SampleDisplacement(ref worldPos, ref displacement);
+            return SampleDisplacement(worldPos, out displacement);
         }
 
-        public bool SampleHeight(ref Vector3 worldPos, ref float height)
+        public bool SampleHeight(Vector3 worldPos, out float height)
         {
-            height = SampleHeight(ref worldPos, 0f);
+            height = SampleHeight(worldPos, 0f);
             return true;
         }
 
@@ -537,30 +537,30 @@ namespace Crest
             OnDisable();
 
         }
-        public bool SampleDisplacementInArea(ref Vector3 worldPos, ref Vector3 displacement)
+        public bool SampleDisplacementInArea(Vector3 worldPos, out Vector3 displacement)
         {
             // revert to usual function
-            return SampleDisplacement(ref worldPos, ref displacement);
+            return SampleDisplacement(worldPos, out displacement);
         }
-        public bool SampleHeightInArea(ref Vector3 worldPos, ref float height)
+        public bool SampleHeightInArea(Vector3 worldPos, out float height)
         {
             // revert to usual function
-            return SampleHeight(ref worldPos, ref height);
+            return SampleHeight(worldPos, out height);
         }
 
-        public bool SampleNormal(ref Vector3 undisplacedWorldPos, ref Vector3 normal)
+        public bool SampleNormal(Vector3 undisplacedWorldPos, out Vector3 normal)
         {
-            normal = GetNormal(ref undisplacedWorldPos, 0f);
+            normal = GetNormal(undisplacedWorldPos, 0f);
             return true;
         }
-        public bool SampleNormal(ref Vector3 undisplacedWorldPos, ref Vector3 normal, float minSpatialLength)
+        public bool SampleNormal(Vector3 undisplacedWorldPos, out Vector3 normal, float minSpatialLength)
         {
             Debug.LogWarning("ShapeGerstnerBatched: minSpatialLength not implemented for GetNormal(), this parameter will be ignored.", this);
-            normal = GetNormal(ref undisplacedWorldPos, 0f);
+            normal = GetNormal(undisplacedWorldPos, 0f);
             return true;
         }
 
-        public bool ComputeUndisplacedPosition(ref Vector3 worldPos, ref Vector3 undisplacedWorldPos)
+        public bool ComputeUndisplacedPosition(Vector3 worldPos, out Vector3 undisplacedWorldPos)
         {
             // fpi - guess should converge to location that displaces to the target position
             Vector3 guess = worldPos;
@@ -568,8 +568,8 @@ namespace Crest
             // sufficient for most applications. for high chop values or really stormy conditions there may
             // be some error here. one could also terminate iteration based on the size of the error, this is
             // worth trying but is left as future work for now.
-            Vector3 disp = Vector3.zero;
-            for (int i = 0; i < 4 && SampleDisplacement(ref guess, ref disp); i++)
+            Vector3 disp;
+            for (int i = 0; i < 4 && SampleDisplacement(guess, out disp); i++)
             {
                 Vector3 error = guess + disp - worldPos;
                 guess.x -= error.x;

--- a/src/unity/Assets/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/src/unity/Assets/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -374,17 +374,18 @@ namespace Crest
             return cp;
         }
 
-        public Vector3 GetPositionDisplacedToPosition(Vector3 displacedWorldPos, float toff)
+
+        public Vector3 GetPositionDisplacedToPosition(ref Vector3 in__displacedWorldPos, float toff)
         {
             // fpi - guess should converge to location that displaces to the target position
-            Vector3 guess = displacedWorldPos;
+            Vector3 guess = in__displacedWorldPos;
             // 2 iterations was enough to get very close when chop = 1, added 2 more which should be
             // sufficient for most applications. for high chop values or really stormy conditions there may
             // be some error here. one could also terminate iteration based on the size of the error, this is
             // worth trying but is left as future work for now.
             for (int i = 0; i < 4; i++)
             {
-                Vector3 error = guess + SampleDisplacement(guess, toff) - displacedWorldPos;
+                Vector3 error = guess + SampleDisplacement(ref guess, toff) - in__displacedWorldPos;
                 guess.x -= error.x;
                 guess.z -= error.z;
             }
@@ -394,11 +395,11 @@ namespace Crest
             return guess;
         }
 
-        public Vector3 SampleDisplacement(Vector3 worldPos, float toff)
+        public Vector3 SampleDisplacement(ref Vector3 in__worldPos, float toff)
         {
             if (_amplitudes == null) return Vector3.zero;
 
-            Vector2 pos = new Vector2(worldPos.x, worldPos.z);
+            Vector2 pos = new Vector2(in__worldPos.x, in__worldPos.z);
             float mytime = Time.time + toff;
             float windAngle = OceanRenderer.Instance._windDirectionAngle;
 
@@ -429,11 +430,11 @@ namespace Crest
         }
 
         // compute normal to a surface with a parameterization - equation 14 here: http://mathworld.wolfram.com/NormalVector.html
-        public Vector3 GetNormal(Vector3 worldPos, float toff)
+        public Vector3 GetNormal(ref Vector3 in__worldPos, float toff)
         {
             if (_amplitudes == null) return Vector3.zero;
 
-            var pos = new Vector2(worldPos.x, worldPos.z);
+            var pos = new Vector2(in__worldPos.x, in__worldPos.z);
             float mytime = Time.time + toff;
             float windAngle = OceanRenderer.Instance._windDirectionAngle;
 
@@ -466,21 +467,21 @@ namespace Crest
             return Vector3.Cross(delfdelz, delfdelx).normalized;
         }
 
-        public float SampleHeight(Vector3 worldPos, float toff)
+        public float SampleHeight(ref Vector3 in__worldPos, float toff)
         {
-            Vector3 posFlatland = worldPos;
+            Vector3 posFlatland = in__worldPos;
             posFlatland.y = OceanRenderer.Instance.transform.position.y;
 
-            Vector3 undisplacedPos = GetPositionDisplacedToPosition(posFlatland, toff);
+            Vector3 undisplacedPos = GetPositionDisplacedToPosition(ref posFlatland, toff);
 
-            return posFlatland.y + SampleDisplacement(undisplacedPos, toff).y;
+            return posFlatland.y + SampleDisplacement(ref undisplacedPos, toff).y;
         }
 
-        public Vector3 GetSurfaceVelocity(Vector3 worldPos, float toff)
+        public Vector3 GetSurfaceVelocity(ref Vector3 in__worldPos, float toff)
         {
             if (_amplitudes == null) return Vector3.zero;
 
-            Vector2 pos = new Vector2(worldPos.x, worldPos.z);
+            Vector2 pos = new Vector2(in__worldPos.x, in__worldPos.z);
             float mytime = Time.time + toff;
             float windAngle = OceanRenderer.Instance._windDirectionAngle;
 
@@ -510,20 +511,20 @@ namespace Crest
             return result;
         }
 
-        public bool SampleDisplacement(Vector3 worldPos, out Vector3 displacement)
+        public bool SampleDisplacement(ref Vector3 in__worldPos, out Vector3 displacement)
         {
-            displacement = SampleDisplacement(worldPos, 0f);
+            displacement = SampleDisplacement(ref in__worldPos, 0f);
             return true;
         }
 
-        public bool SampleDisplacement(Vector3 worldPos, out Vector3 displacement, float minSpatialLength)
+        public bool SampleDisplacement(ref Vector3 in__worldPos, out Vector3 displacement, float minSpatialLength)
         {
-            return SampleDisplacement(worldPos, out displacement);
+            return SampleDisplacement(ref in__worldPos, out displacement);
         }
 
-        public bool SampleHeight(Vector3 worldPos, out float height)
+        public bool SampleHeight(ref Vector3 in__worldPos, out float height)
         {
-            height = SampleHeight(worldPos, 0f);
+            height = SampleHeight(ref in__worldPos, 0f);
             return true;
         }
 
@@ -537,41 +538,41 @@ namespace Crest
             OnDisable();
 
         }
-        public bool SampleDisplacementInArea(Vector3 worldPos, out Vector3 displacement)
+        public bool SampleDisplacementInArea(ref Vector3 in__worldPos, out Vector3 displacement)
         {
             // revert to usual function
-            return SampleDisplacement(worldPos, out displacement);
+            return SampleDisplacement(ref in__worldPos, out displacement);
         }
-        public bool SampleHeightInArea(Vector3 worldPos, out float height)
+        public bool SampleHeightInArea(ref Vector3 in__worldPos, out float height)
         {
             // revert to usual function
-            return SampleHeight(worldPos, out height);
+            return SampleHeight(ref in__worldPos, out height);
         }
 
-        public bool SampleNormal(Vector3 undisplacedWorldPos, out Vector3 normal)
+        public bool SampleNormal(ref Vector3 in__undisplacedWorldPos, out Vector3 normal)
         {
-            normal = GetNormal(undisplacedWorldPos, 0f);
+            normal = GetNormal(ref in__undisplacedWorldPos, 0f);
             return true;
         }
-        public bool SampleNormal(Vector3 undisplacedWorldPos, out Vector3 normal, float minSpatialLength)
+        public bool SampleNormal(ref Vector3 in__undisplacedWorldPos, out Vector3 normal, float minSpatialLength)
         {
             Debug.LogWarning("ShapeGerstnerBatched: minSpatialLength not implemented for GetNormal(), this parameter will be ignored.", this);
-            normal = GetNormal(undisplacedWorldPos, 0f);
+            normal = GetNormal(ref in__undisplacedWorldPos, 0f);
             return true;
         }
 
-        public bool ComputeUndisplacedPosition(Vector3 worldPos, out Vector3 undisplacedWorldPos)
+        public bool ComputeUndisplacedPosition(ref Vector3 in__worldPos, out Vector3 undisplacedWorldPos)
         {
             // fpi - guess should converge to location that displaces to the target position
-            Vector3 guess = worldPos;
+            Vector3 guess = in__worldPos;
             // 2 iterations was enough to get very close when chop = 1, added 2 more which should be
             // sufficient for most applications. for high chop values or really stormy conditions there may
             // be some error here. one could also terminate iteration based on the size of the error, this is
             // worth trying but is left as future work for now.
             Vector3 disp;
-            for (int i = 0; i < 4 && SampleDisplacement(guess, out disp); i++)
+            for (int i = 0; i < 4 && SampleDisplacement(ref guess, out disp); i++)
             {
-                Vector3 error = guess + disp - worldPos;
+                Vector3 error = guess + disp - in__worldPos;
                 guess.x -= error.x;
                 guess.z -= error.z;
             }


### PR DESCRIPTION
The reason for this change is that ref implies that an input value
can both be read from and written to. However, for some parameters
they were only being read from (so were changed back to pass-by-value,
although the 'in' parameter modifier would be ideal in future versions
of C#).

Furthermore, some parameters were only being written to, so were changed
to `out` parameters.

For further reading see: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/method-parameters