### PR TITLE
Fix/ocean depth baseline

### DIFF
--- a/src/unity/Assets/Crest-Examples/Scripts/OceanDebugGUI.cs
+++ b/src/unity/Assets/Crest-Examples/Scripts/OceanDebugGUI.cs
@@ -17,6 +17,12 @@ public class OceanDebugGUI : MonoBehaviour
 
     private void Start()
     {
+        if (OceanRenderer.Instance == null)
+        {
+            enabled = false;
+            return;
+        }
+
         gerstners = FindObjectsOfType<ShapeGerstnerBatched>();
         // i am getting the array in the reverse order compared to the hierarchy which bugs me. sort them based on sibling index,
         // which helps if the gerstners are on sibling GOs.

--- a/src/unity/Assets/Crest/Scripts/Helpers/RenderAlphaOnSurface.cs
+++ b/src/unity/Assets/Crest/Scripts/Helpers/RenderAlphaOnSurface.cs
@@ -17,6 +17,12 @@ namespace Crest
 
         private void Start()
         {
+            if (OceanRenderer.Instance == null)
+            {
+                enabled = false;
+                return;
+            }
+
             _rend = GetComponent<Renderer>();
             _mesh = GetComponent<MeshFilter>().mesh;
             _boundsLocal = _mesh.bounds;

--- a/src/unity/Assets/Crest/Scripts/LodData/LodDataSeaFloorDepth.cs
+++ b/src/unity/Assets/Crest/Scripts/LodData/LodDataSeaFloorDepth.cs
@@ -13,7 +13,7 @@ namespace Crest
         public override SimType LodDataType { get { return SimType.SeaFloorDepth; } }
         public override SimSettingsBase CreateDefaultSettings() { return null; }
         public override void UseSettings(SimSettingsBase settings) { }
-        public override RenderTextureFormat TextureFormat { get { return RenderTextureFormat.RHalf; } }
+        public override RenderTextureFormat TextureFormat { get { return RenderTextureFormat.RFloat; } }
         public override CameraClearFlags CamClearFlags { get { return CameraClearFlags.Color; } }
         public override RenderTexture DataTexture { get { return _rtOceanDepth; } }
 
@@ -104,7 +104,7 @@ namespace Crest
             _bufOceanDepth.Clear();
 
             _bufOceanDepth.SetRenderTarget(_rtOceanDepth);
-            _bufOceanDepth.ClearRenderTarget(false, true, Color.red * 10000f);
+            _bufOceanDepth.ClearRenderTarget(false, true, Color.black);
 
             foreach (var entry in _depthRenderers)
             {

--- a/src/unity/Assets/Crest/Scripts/OceanDepthCache.cs
+++ b/src/unity/Assets/Crest/Scripts/OceanDepthCache.cs
@@ -118,7 +118,8 @@ namespace Crest
                 _camDepthCache.targetTexture = _cache;
                 _camDepthCache.cullingMask = layerMask;
                 _camDepthCache.clearFlags = CameraClearFlags.SolidColor;
-                _camDepthCache.backgroundColor = Color.red * 10000f;
+                // 0 means '0m above very deep sea floor'
+                _camDepthCache.backgroundColor = Color.black;
                 _camDepthCache.enabled = false;
                 _camDepthCache.allowMSAA = false;
                 // I'd prefer to destroy the cam object, but I found sometimes (on first start of editor) it will fail to render.

--- a/src/unity/Assets/Crest/Scripts/OceanDepthCache.cs
+++ b/src/unity/Assets/Crest/Scripts/OceanDepthCache.cs
@@ -40,6 +40,12 @@ namespace Crest
                 return;
             }
 
+            if (OceanRenderer.Instance == null)
+            {
+                enabled = false;
+                return;
+            }
+
             if (_populateOnStartup)
             {
                 PopulateCache();

--- a/src/unity/Assets/Crest/Scripts/RenderOceanDepth.cs
+++ b/src/unity/Assets/Crest/Scripts/RenderOceanDepth.cs
@@ -13,7 +13,7 @@ namespace Crest
 
         private void OnEnable()
         {
-            var mat = _renderDepthMaterial ?? new Material(Shader.Find("Ocean/Ocean Depth"));
+            var mat = _renderDepthMaterial != null ? _renderDepthMaterial : new Material(Shader.Find("Ocean/Ocean Depth"));
             LodDataSeaFloorDepth.AddRenderOceanDepth(GetComponent<Renderer>(), mat);
         }
 

--- a/src/unity/Assets/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/src/unity/Assets/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -65,7 +65,13 @@ namespace Crest
 
         void Start()
         {
-            if( _spectrum == null )
+            if (OceanRenderer.Instance == null)
+            {
+                enabled = false;
+                return;
+            }
+
+            if ( _spectrum == null )
             {
                 _spectrum = ScriptableObject.CreateInstance<OceanWaveSpectrum>();
                 _spectrum.name = "Default Waves (auto)";

--- a/src/unity/Assets/Crest/Shaders/Ocean.shader
+++ b/src/unity/Assets/Crest/Shaders/Ocean.shader
@@ -197,7 +197,7 @@ Shader "Ocean/Ocean"
 						#endif
 
 						#if _SUBSURFACESHALLOWCOLOUR_ON
-						SampleOceanDepth(_LD_Sampler_SeaFloorDepth_0, uv_0, wt_0, o.lodAlpha_worldXZUndisplaced_oceanDepth.w);
+						SampleSeaFloorHeightAboveBaseline(_LD_Sampler_SeaFloorDepth_0, uv_0, wt_0, o.lodAlpha_worldXZUndisplaced_oceanDepth.w);
 						#endif
 
 						#if _SHADOWS_ON
@@ -221,13 +221,16 @@ Shader "Ocean/Ocean"
 						#endif
 
 						#if _SUBSURFACESHALLOWCOLOUR_ON
-						SampleOceanDepth(_LD_Sampler_SeaFloorDepth_1, uv_1, wt_1, o.lodAlpha_worldXZUndisplaced_oceanDepth.w);
+						SampleSeaFloorHeightAboveBaseline(_LD_Sampler_SeaFloorDepth_1, uv_1, wt_1, o.lodAlpha_worldXZUndisplaced_oceanDepth.w);
 						#endif
 
 						#if _SHADOWS_ON
 						SampleShadow(_LD_Sampler_Shadow_1, uv_1, wt_1, o.n_shadow.zw);
 						#endif
 					}
+
+					// convert height above -1000m to depth below surface
+					o.lodAlpha_worldXZUndisplaced_oceanDepth.w = DEPTH_BASELINE - o.lodAlpha_worldXZUndisplaced_oceanDepth.w;
 
 					// foam can saturate
 					o.foam_screenPos.x = saturate(o.foam_screenPos.x);

--- a/src/unity/Assets/Crest/Shaders/OceanEmission.hlsl
+++ b/src/unity/Assets/Crest/Shaders/OceanEmission.hlsl
@@ -44,8 +44,8 @@ half3 OceanEmission(float3 worldPos, half oceanDepth, half3 view, half3 n, half3
 #if _SUBSURFACESCATTERING_ON
 	{
 #if _SUBSURFACESHALLOWCOLOUR_ON
-		float deepness = pow(1. - saturate(oceanDepth / _SubSurfaceDepthMax), _SubSurfaceDepthPower);
-		col = lerp(col, _SubSurfaceShallowCol, deepness);
+		float shallowness = pow(1. - saturate(oceanDepth / _SubSurfaceDepthMax), _SubSurfaceDepthPower);
+		col = lerp(col, _SubSurfaceShallowCol, shallowness);
 #endif
 
 #if _SUBSURFACEHEIGHTLERP_ON

--- a/src/unity/Assets/Crest/Shaders/OceanLODData.hlsl
+++ b/src/unity/Assets/Crest/Shaders/OceanLODData.hlsl
@@ -41,7 +41,7 @@ float2 LD_1_UVToWorld(in float2 i_uv) { return LD_UVToWorld(i_uv, _LD_Pos_Scale_
 
 
 // Bias ocean floor depth so that default (0) values in texture are not interpreted as shallow and generating foam everywhere
-#define DEPTH_BIAS 100.
+#define DEPTH_BASELINE 1000.
 
 
 // Sampling functions
@@ -72,9 +72,9 @@ void SampleFlow(in sampler2D i_oceanFlowSampler, float2 i_uv, in float i_wt, ino
 	io_flow += i_wt * tex2Dlod(i_oceanFlowSampler, uv).xy;
 }
 
-void SampleOceanDepth(in sampler2D i_oceanDepthSampler, float2 i_uv, in float i_wt, inout half io_oceanDepth)
+void SampleSeaFloorHeightAboveBaseline(in sampler2D i_oceanDepthSampler, float2 i_uv, in float i_wt, inout half io_oceanDepth)
 {
-	io_oceanDepth += i_wt * (tex2Dlod(i_oceanDepthSampler, float4(i_uv, 0., 0.)).x + DEPTH_BIAS);
+	io_oceanDepth += i_wt * (tex2Dlod(i_oceanDepthSampler, float4(i_uv, 0., 0.)).x);
 }
 
 void SampleShadow(in sampler2D i_oceanShadowSampler, float2 i_uv, in float i_wt, inout fixed2 io_shadow)

--- a/src/unity/Assets/Crest/Shaders/Resources/OceanDepthsCache.shader
+++ b/src/unity/Assets/Crest/Shaders/Resources/OceanDepthsCache.shader
@@ -15,7 +15,9 @@ Shader "Ocean/Ocean Depth Cache"
 		Pass
 		{
 			// Min blending to take the min of all depths. Similar in spirit to zbuffer'd visibility when viewing from top down.
-			BlendOp Min
+			// To confuse matters further, ocean depth is now more like 'sea floor altitude' - a height above a deep water value,
+			// so values are increasing in Y and we need to take the MAX of all depths.
+			BlendOp Max
 
 			CGPROGRAM
 			#pragma vertex vert

--- a/src/unity/Assets/Crest/Shaders/Shapes/ShapeGerstnerBatch.shader
+++ b/src/unity/Assets/Crest/Shaders/Shapes/ShapeGerstnerBatch.shader
@@ -68,7 +68,7 @@ Shader "Ocean/Shape/Gerstner Batch"
 					const half minWavelength = MinWavelengthForCurrentOrthoCamera();
 			
 					// sample ocean depth (this render target should 1:1 match depth texture, so UVs are trivial)
-					const half depth = tex2D(_LD_Sampler_SeaFloorDepth_0, i.vertex.xy / _ScreenParams.xy).x + DEPTH_BIAS;
+					const half depth = DEPTH_BASELINE - tex2D(_LD_Sampler_SeaFloorDepth_0, i.vertex.xy / _ScreenParams.xy).x;
 					half3 result = (half3)0.;
 
 					// unrolling this loop once helped SM Issue Utilization and some other stats, but the GPU time is already very low so leaving this for now

--- a/src/unity/Assets/Crest/Shaders/Simulation/Resources/ShapeSimFoam.shader
+++ b/src/unity/Assets/Crest/Shaders/Simulation/Resources/ShapeSimFoam.shader
@@ -91,7 +91,7 @@ Shader "Ocean/Shape/Sim/Foam"
 					foam += 5. * _SimDeltaTime * _WaveFoamStrength * saturate(_WaveFoamCoverage - det);
 
 					// add foam in shallow water
-					float signedOceanDepth = tex2Dlod(_LD_Sampler_SeaFloorDepth_1, uv).x + DEPTH_BIAS + disp.y;
+					float signedOceanDepth = DEPTH_BASELINE - tex2Dlod(_LD_Sampler_SeaFloorDepth_1, uv).x + disp.y;
 					foam += _ShorelineFoamStrength * _SimDeltaTime * saturate(1. - signedOceanDepth / _ShorelineFoamMaxDepth);
 
 					return foam;

--- a/src/unity/Assets/Crest/Shaders/Simulation/Resources/ShapeSimWave.shader
+++ b/src/unity/Assets/Crest/Shaders/Simulation/Resources/ShapeSimWave.shader
@@ -111,7 +111,7 @@ Shader "Ocean/Shape/Sim/2D Wave Equation"
 					// eventually break. i model "Deep" water, but then simply ramp down waves in non-deep water with a linear multiplier.
 					// http://hyperphysics.phy-astr.gsu.edu/hbase/Waves/watwav2.html
 					// http://hyperphysics.phy-astr.gsu.edu/hbase/watwav.html#c1
-					float waterSignedDepth = tex2D(_LD_Sampler_SeaFloorDepth_1, float4(i.uv, 0., 0.)).x + DEPTH_BIAS;
+					float waterSignedDepth = DEPTH_BASELINE - tex2D(_LD_Sampler_SeaFloorDepth_1, float4(i.uv, 0., 0.)).x;
 					float depthMul = 1. - (1. - saturate(2.0 * waterSignedDepth / wavelength)) * dt * 2.;
 					ftp *= depthMul;
 					ft *= depthMul;


### PR DESCRIPTION
FYI @dizzy2003 - i'm aware you guys have your own ocean depth shaders? I've changed the meaning of this ocean depth to be 'height above -1000m' instead of what it used to be which was something like 'water depth plus 100'. some more information from the commit:

We need '0' to mean deep water. This is required so that when lods are faded in/out, it can fade to 0 (deep). It also means that outside the biggest lod the value can be 0 and not appear to be shallow. This fix changes the meaning of the depths - it is now the height of the sea floor above some deep value (currently -1000m).

the reason for this change: i discovered that the outer skirt of geometry was being shaded as shallow water. so there was a bright blue region near the horizon. it wasn't noticeable for some views but would become worse with less LODs or for high viewpoints, so im changing the meaning of depth so it works in all scenarios.

if you have any thoughts etc let me know
