### PR TITLE
Make readback texture format robust

### DIFF
--- a/src/unity/Assets/Crest/Scripts/LodData/LodDataAnimatedWaves.cs
+++ b/src/unity/Assets/Crest/Scripts/LodData/LodDataAnimatedWaves.cs
@@ -44,6 +44,7 @@ namespace Crest
             base.Start();
 
             _dataReadback = GetComponent<ReadbackLodData>();
+            _dataReadback.SetTextureFormat(TextureFormat);
         }
         public void HookCombinePass(Camera camera, CameraEvent onEvent)
         {

--- a/src/unity/Assets/Crest/Scripts/LodData/LodDataFlow.cs
+++ b/src/unity/Assets/Crest/Scripts/LodData/LodDataFlow.cs
@@ -21,7 +21,7 @@ namespace Crest
             base.Start();
 
             _dataReadback = GetComponent<ReadbackLodData>();
-            _dataReadback._textureFormat = ReadbackLodData.TexFormat.RGHalf;
+            _dataReadback.SetTextureFormat(TextureFormat);
             _dataReadback._active = true;
         }
 

--- a/src/unity/Assets/Crest/Scripts/LodData/ReadbackLodData.cs
+++ b/src/unity/Assets/Crest/Scripts/LodData/ReadbackLodData.cs
@@ -18,15 +18,6 @@ namespace Crest
             public LodTransform.RenderData _renderData;
         }
 
-        public enum TexFormat
-        {
-            NotSet = 0,
-            RHalf = 1,
-            RGHalf = 2,
-            RGBAHalf = 4,
-        }
-        public TexFormat _textureFormat = TexFormat.RGBAHalf;
-
         Queue<ReadbackRequest> _requests = new Queue<ReadbackRequest>();
         const int MAX_REQUESTS = 8;
 
@@ -36,10 +27,40 @@ namespace Crest
 
         public bool _active = true;
 
+        public enum TexFormat
+        {
+            NotSet = 0,
+            RHalf = 1,
+            RGHalf = 2,
+            RGBAHalf = 4,
+        }
+        [SerializeField] private TexFormat _textureFormat = TexFormat.NotSet;
+
+        public void SetTextureFormat(RenderTextureFormat fmt)
+        {
+            switch(fmt)
+            {
+                case RenderTextureFormat.RHalf:
+                    _textureFormat = TexFormat.RHalf;
+                    break;
+                case RenderTextureFormat.RGHalf:
+                    _textureFormat = TexFormat.RGHalf;
+                    break;
+                case RenderTextureFormat.ARGBHalf:
+                    _textureFormat = TexFormat.RGBAHalf;
+                    break;
+                default:
+                    Debug.LogError("Unsupported texture format for readback: " + fmt.ToString(), this);
+                    break;
+            }
+        }
+
         private void Update()
         {
             if (_active)
             {
+                Debug.Assert(_textureFormat != TexFormat.NotSet, "ReadbackLodData: Texture format must be set.", this);
+
                 UpdateReadback(Cam, LT._renderData);
             }
         }


### PR DESCRIPTION

@moosichu tried to make the tex format robust, constrained and error resistant, while still avoiding the need for a separate channel count field.. for now..