### PR TITLE
Refactor/drive shader keywords

### DIFF
--- a/src/unity/Assets/Crest/Materials/Ocean.mat
+++ b/src/unity/Assets/Crest/Materials/Ocean.mat
@@ -10,7 +10,7 @@ Material:
   m_Shader: {fileID: 4800000, guid: 668aecf91371c8b4997e42c0c7b19527, type: 3}
   m_ShaderKeywords: _APPLYNORMALMAPPING_ON _CAUSTICS_ON _COMPILESHADERWITHDEBUGINFO_ON
     _COMPUTEDIRECTIONALLIGHT_ON _DEBUGMULTIPLYBYLIGHT0COLOR_ON _FOAM3DLIGHTING_ON
-    _FOAM_ON _SUBSURFACEHEIGHTLERP_ON _SUBSURFACESCATTERING_ON _SUBSURFACESHALLOWCOLOUR_ON
+    _SUBSURFACEHEIGHTLERP_ON _SUBSURFACESCATTERING_ON _SUBSURFACESHALLOWCOLOUR_ON
     _TRANSPARENCY_ON
   m_LightmapFlags: 5
   m_EnableInstancingVariants: 0
@@ -99,7 +99,7 @@ Material:
     - _DebugVisualiseShapeSample: 0
     - _DirectionalLightBoost: 7
     - _DirectionalLightFallOff: 275
-    - _Foam: 1
+    - _Flow: 0
     - _Foam3DLighting: 1
     - _FoamScale: 10
     - _FresnelPower: 5
@@ -113,7 +113,6 @@ Material:
     - _ProceduralSky: 0
     - _RefractAmt: 0
     - _S: 1
-    - _Shadows: 0
     - _ShorelineFoamMinDepth: 0.27
     - _SkyDirectionality: 0.875
     - _StartLevel: 0.157

--- a/src/unity/Assets/Crest/Scripts/LodData/LodDataFlow.cs
+++ b/src/unity/Assets/Crest/Scripts/LodData/LodDataFlow.cs
@@ -1,7 +1,6 @@
 ﻿// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
 using UnityEngine;
-using UnityEngine.Rendering;
 
 namespace Crest
 {
@@ -17,6 +16,8 @@ namespace Crest
         public override void UseSettings(SimSettingsBase settings) {}
         public override SimSettingsBase CreateDefaultSettings() { return null;}
 
+        static readonly string SHADER_KEYWORD = "_FLOW_ON";
+
         protected override void Start() {
             base.Start();
 
@@ -25,7 +26,15 @@ namespace Crest
             _dataReadback._active = true;
         }
 
-        void OnDisable() {
+        void OnEnable()
+        {
+            OceanRenderer.Instance.OceanMaterial.EnableKeyword(SHADER_KEYWORD);
+        }
+
+        void OnDisable()
+        {
+            OceanRenderer.Instance.OceanMaterial.DisableKeyword(SHADER_KEYWORD);
+
             // free native array when component removed or destroyed
             if (_dataReadback._dataNative.IsCreated)
             {

--- a/src/unity/Assets/Crest/Scripts/LodData/LodDataFoam.cs
+++ b/src/unity/Assets/Crest/Scripts/LodData/LodDataFoam.cs
@@ -14,6 +14,8 @@ namespace Crest
         public override RenderTextureFormat TextureFormat { get { return RenderTextureFormat.RHalf; } }
         protected override Camera[] SimCameras { get { return OceanRenderer.Instance._camsFoam; } }
 
+        static readonly string SHADER_KEYWORD = "_FOAM_ON";
+
         public override SimSettingsBase CreateDefaultSettings()
         {
             var settings = ScriptableObject.CreateInstance<SimSettingsFoam>();
@@ -48,6 +50,16 @@ namespace Crest
             {
                 animWaves[lodIdx].LDFlow.BindResultData(1, simMaterial);
             }
+        }
+
+        private void OnEnable()
+        {
+            OceanRenderer.Instance.OceanMaterial.EnableKeyword(SHADER_KEYWORD);
+        }
+
+        private void OnDisable()
+        {
+            OceanRenderer.Instance.OceanMaterial.DisableKeyword(SHADER_KEYWORD);
         }
 
         SimSettingsFoam Settings { get { return _settings as SimSettingsFoam; } }

--- a/src/unity/Assets/Crest/Scripts/LodData/LodDataShadow.cs
+++ b/src/unity/Assets/Crest/Scripts/LodData/LodDataShadow.cs
@@ -1,4 +1,6 @@
-﻿using UnityEngine;
+﻿// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+using UnityEngine;
 using UnityEngine.Rendering;
 
 namespace Crest
@@ -14,6 +16,8 @@ namespace Crest
         public override RenderTextureFormat TextureFormat { get { return RenderTextureFormat.RG16; } }
         public override CameraClearFlags CamClearFlags { get { return CameraClearFlags.Color; } }
         public override RenderTexture DataTexture { get { return _shadowData[_rtIndex]; } }
+
+        static readonly string SHADER_KEYWORD = "_SHADOWS_ON";
 
         public static bool s_processData = true;
 
@@ -176,11 +180,15 @@ namespace Crest
         void OnEnable()
         {
             RemoveCommandBuffers();
+
+            OceanRenderer.Instance.OceanMaterial.EnableKeyword(SHADER_KEYWORD);
         }
 
         void OnDisable()
         {
             RemoveCommandBuffers();
+
+            OceanRenderer.Instance.OceanMaterial.DisableKeyword(SHADER_KEYWORD);
         }
 
         void RemoveCommandBuffers()

--- a/src/unity/Assets/Crest/Scripts/Reflection/OceanPlanarReflection.cs
+++ b/src/unity/Assets/Crest/Scripts/Reflection/OceanPlanarReflection.cs
@@ -24,6 +24,8 @@ namespace Crest
         Camera _camViewpoint;
         Camera _camReflections;
 
+        static readonly string SHADER_KEYWORD = "_PLANARREFLECTIONS_ON";
+
         public bool _hideCameraGameobject = true;
 
         private void Start()
@@ -201,9 +203,16 @@ namespace Crest
             reflectionMat.m33 = 1F;
         }
 
-        // Cleanup all the objects we possibly have created
-        void OnDisable()
+        private void OnEnable()
         {
+            OceanRenderer.Instance.OceanMaterial.EnableKeyword(SHADER_KEYWORD);
+        }
+
+        private void OnDisable()
+        {
+            OceanRenderer.Instance.OceanMaterial.DisableKeyword(SHADER_KEYWORD);
+
+            // Cleanup all the objects we possibly have created
             if (_reflectionTexture)
             {
                 Destroy(_reflectionTexture);

--- a/src/unity/Assets/Crest/Shaders/Ocean.shader
+++ b/src/unity/Assets/Crest/Shaders/Ocean.shader
@@ -4,61 +4,90 @@ Shader "Ocean/Ocean"
 {
 	Properties
 	{
-		[Toggle] _ApplyNormalMapping("Apply Normal Mapping", Float) = 1
-		[NoScaleOffset] _Normals ( "    Normals", 2D ) = "bump" {}
-		_NormalsStrength("    Strength", Range(0.01, 2.0)) = 0.3
-		_NormalsScale("    Scale", Range(0.01, 50.0)) = 1.0
+		[Header(Normal Mapping)]
+		[Toggle] _ApplyNormalMapping("Enable", Float) = 1
+		[NoScaleOffset] _Normals ( "Normal Map", 2D ) = "bump" {}
+		_NormalsStrength("Strength", Range(0.01, 2.0)) = 0.3
+		_NormalsScale("Scale", Range(0.01, 50.0)) = 1.0
+
+		[Header(Scattering)]
 		_Diffuse("Diffuse", Color) = (0.2, 0.05, 0.05, 1.0)
-		[Toggle] _ComputeDirectionalLight("Add Directional Light", Float) = 1
-		_DirectionalLightFallOff("    Fall-Off", Range(1.0, 4096.0)) = 128.0
-		_DirectionalLightBoost("    Boost", Range(0.0, 512.0)) = 5.0
-		[Toggle] _SubSurfaceScattering("Sub-Surface Scattering", Float) = 1
-		_SubSurfaceColour("    Colour", Color) = (0.0, 0.48, 0.36)
-		_SubSurfaceBase("    Base Mul", Range(0.0, 2.0)) = 0.6
-		_SubSurfaceSun("    Sun Mul", Range(0.0, 10.0)) = 0.8
-		_SubSurfaceSunFallOff("    Sun Fall-Off", Range(1.0, 16.0)) = 4.0
-		[Toggle] _SubSurfaceHeightLerp("Sub-Surface Scattering Height Lerp", Float) = 1
-		_SubSurfaceHeightMax("    Height Max", Range(0.0, 50.0)) = 3.0
-		_SubSurfaceHeightPower("    Height Power", Range(0.01, 10.0)) = 1.0
-		_SubSurfaceCrestColour("    Crest Colour", Color) = (0.42, 0.69, 0.52)
-		[Toggle] _SubSurfaceShallowColour("Sub-Surface Shallow Colour", Float) = 1
-		_SubSurfaceDepthMax("    Depth Max", Range(0.01, 50.0)) = 3.0
-		_SubSurfaceDepthPower("    Depth Power", Range(0.01, 10.0)) = 1.0
-		_SubSurfaceShallowCol("    Shallow Colour", Color) = (0.42, 0.75, 0.69)
-		[NoScaleOffset] _FoamTexture ( "Foam Texture", 2D ) = "white" {}
-		_FoamScale("Foam Scale", Range(0.01, 50.0)) = 10.0
-		_FoamWhiteColor("Foam White Foam Color", Color) = (1.0, 1.0, 1.0, 1.0)
-		_FoamBubbleColor("Foam Bubble Foam Color", Color) = (0.64, 0.83, 0.82, 1.0)
-		_ShorelineFoamMinDepth("Foam Shoreline Foam Min Depth", Range(0.01, 5.0)) = 0.27
-		_WaveFoamFeather("Foam Wave Foam Feather", Range(0.001,1.0)) = 0.32
-		_WaveFoamBubblesCoverage("Foam Wave Foam Bubbles Coverage", Range(0.0,5.0)) = 0.95
-		[Toggle] _Foam3DLighting("Foam 3D Lighting", Float) = 1
-		_WaveFoamLightScale("    Light Scale", Range(0.0, 2.0)) = 0.7
-		_WaveFoamNormalStrength("    Normals Strength", Range(0.0, 30.0)) = 3.5
-		_WaveFoamSpecularFallOff("    Specular Fall-Off", Range(1.0, 512.0)) = 275.0
-		_WaveFoamSpecularBoost("    Specular Boost", Range(0.0, 16.0)) = 4.0
-		[Toggle] _Transparency("Transparency", Float) = 1
-		_DepthFogDensity("    Density", Vector) = (0.28, 0.16, 0.24, 1.0)
-		[Toggle] _Caustics("Caustics", Float) = 1
-		[NoScaleOffset] _CausticsTexture ( "    Caustics", 2D ) = "black" {}
-		_CausticsTextureScale("    Scale", Range(0.0, 25.0)) = 5.0
-		_CausticsTextureAverage("    Texture Average Value", Range(0.0, 1.0)) = 0.07
-		_CausticsStrength("    Strength", Range(0.0, 10.0)) = 3.2
-		_CausticsFocalDepth("    Focal Depth", Range(0.0, 25.0)) = 2.0
-		_CausticsDepthOfField("    Depth Of Field", Range(0.01, 10.0)) = 0.33
-		_CausticsDistortionScale("    Distortion Scale", Range(0.01, 50.0)) = 10.0
-		_CausticsDistortionStrength("    Distortion Strength", Range(0.0, 0.25)) = 0.075
-		_FresnelPower("Fresnel Power", Range(0.0, 20.0)) = 3.0
-		[NoScaleOffset] _Skybox ("Skybox", CUBE) = "" {}
-		[Toggle] _ProceduralSky("Procedural Sky", Float) = 0
-		[HDR] _SkyBase("    Base", Color) = (1.0, 1.0, 1.0, 1.0)
-		[HDR] _SkyTowardsSun("    Towards Sun", Color) = (1.0, 1.0, 1.0, 1.0)
-		_SkyDirectionality("    Directionality", Range(0.0, 0.99)) = 1.0
-		[HDR] _SkyAwayFromSun("    Away From Sun", Color) = (1.0, 1.0, 1.0, 1.0)
 		_DiffuseShadow("Shadow Diffuse Colour", Color) = (0.2, 0.05, 0.05, 1.0)
 		_SubSurfaceShallowColShadow("Shadow Shallow Colour", Color) = (0.42, 0.75, 0.69)
+
+		[Header(Directional Scattering)]
+		[Toggle] _SubSurfaceScattering("Enable", Float) = 1
+		_SubSurfaceColour("Colour", Color) = (0.0, 0.48, 0.36)
+		_SubSurfaceBase("Base Mul", Range(0.0, 2.0)) = 0.6
+		_SubSurfaceSun("Sun Mul", Range(0.0, 10.0)) = 0.8
+		_SubSurfaceSunFallOff("Sun Fall-Off", Range(1.0, 16.0)) = 4.0
+
+		[Header(Height Based Scattering)]
+		[Toggle] _SubSurfaceHeightLerp("Enable", Float) = 1
+		_SubSurfaceHeightMax("Height Max", Range(0.0, 50.0)) = 3.0
+		_SubSurfaceHeightPower("Height Power", Range(0.01, 10.0)) = 1.0
+		_SubSurfaceCrestColour("Crest Colour", Color) = (0.42, 0.69, 0.52)
+
+		[Header(Shallow Scattering)]
+		[Toggle] _SubSurfaceShallowColour("Enable", Float) = 1
+		_SubSurfaceDepthMax("Depth Max", Range(0.01, 50.0)) = 3.0
+		_SubSurfaceDepthPower("Depth Power", Range(0.01, 10.0)) = 1.0
+		_SubSurfaceShallowCol("Shallow Colour", Color) = (0.42, 0.75, 0.69)
+
+		[Header(Reflection Environment)]
+		_FresnelPower("Fresnel Power", Range(0.0, 20.0)) = 3.0
+		[NoScaleOffset] _Skybox ("Skybox", CUBE) = "" {}
+
+		[Header(Procedural Skybox)]
+		[Toggle] _ProceduralSky("Enable", Float) = 0
+		[HDR] _SkyBase("Base", Color) = (1.0, 1.0, 1.0, 1.0)
+		[HDR] _SkyTowardsSun("Towards Sun", Color) = (1.0, 1.0, 1.0, 1.0)
+		_SkyDirectionality("Directionality", Range(0.0, 0.99)) = 1.0
+		[HDR] _SkyAwayFromSun("Away From Sun", Color) = (1.0, 1.0, 1.0, 1.0)
+
+		[Header(Add Directional Light)]
+		[Toggle] _ComputeDirectionalLight("Enable", Float) = 1
+		_DirectionalLightFallOff("Fall-Off", Range(1.0, 4096.0)) = 128.0
+		_DirectionalLightBoost("Boost", Range(0.0, 512.0)) = 5.0
+
+		[Header(Foam)]
+		[NoScaleOffset] _FoamTexture ( "Texture", 2D ) = "white" {}
+		_FoamScale("Scale", Range(0.01, 50.0)) = 10.0
+		_FoamWhiteColor("White Foam Color", Color) = (1.0, 1.0, 1.0, 1.0)
+		_FoamBubbleColor("Bubble Foam Color", Color) = (0.64, 0.83, 0.82, 1.0)
+		_ShorelineFoamMinDepth("Shoreline Foam Min Depth", Range(0.01, 5.0)) = 0.27
+		_WaveFoamFeather("Wave Foam Feather", Range(0.001,1.0)) = 0.32
+		_WaveFoamBubblesCoverage("Wave Foam Bubbles Coverage", Range(0.0,5.0)) = 0.95
+
+		[Header(Foam 3D Lighting)]
+		[Toggle] _Foam3DLighting("Enable", Float) = 1
+		_WaveFoamLightScale("Light Scale", Range(0.0, 2.0)) = 0.7
+		_WaveFoamNormalStrength("Normals Strength", Range(0.0, 30.0)) = 3.5
+		_WaveFoamSpecularFallOff("Specular Fall-Off", Range(1.0, 512.0)) = 275.0
+		_WaveFoamSpecularBoost("Specular Boost", Range(0.0, 16.0)) = 4.0
+
+		[Header(Transparency)]
+		[Toggle] _Transparency("Enable", Float) = 1
+		_DepthFogDensity("Density", Vector) = (0.28, 0.16, 0.24, 1.0)
+
+		[Header(Caustics)]
+		[Toggle] _Caustics("Enable", Float) = 1
+		[NoScaleOffset] _CausticsTexture ("Caustics", 2D ) = "black" {}
+		_CausticsTextureScale("Scale", Range(0.0, 25.0)) = 5.0
+		_CausticsTextureAverage("Texture Average Value", Range(0.0, 1.0)) = 0.07
+		_CausticsStrength("Strength", Range(0.0, 10.0)) = 3.2
+		_CausticsFocalDepth("Focal Depth", Range(0.0, 25.0)) = 2.0
+		_CausticsDepthOfField("Depth Of Field", Range(0.01, 10.0)) = 0.33
+		_CausticsDistortionScale("Distortion Scale", Range(0.01, 50.0)) = 10.0
+		_CausticsDistortionStrength("Distortion Strength", Range(0.0, 0.25)) = 0.075
+
+		[Header(Flow)]
 		[Toggle] _Flow("Enable", Float) = 0
+
+		[Header(Render State)]
 		[Enum(CullMode)] _CullMode("Cull Mode", Int) = 2
+
+		[Header(Debug Options)]
 		[Toggle] _DebugDisableShapeTextures("Debug Disable Shape Textures", Float) = 0
 		[Toggle] _DebugVisualiseShapeSample("Debug Visualise Shape Sample", Float) = 0
 		[Toggle] _DebugVisualiseFlow("Debug Visualise Flow", Float) = 0

--- a/src/unity/Assets/Crest/Shaders/Ocean.shader
+++ b/src/unity/Assets/Crest/Shaders/Ocean.shader
@@ -25,14 +25,13 @@ Shader "Ocean/Ocean"
 		_SubSurfaceDepthMax("    Depth Max", Range(0.01, 50.0)) = 3.0
 		_SubSurfaceDepthPower("    Depth Power", Range(0.01, 10.0)) = 1.0
 		_SubSurfaceShallowCol("    Shallow Colour", Color) = (0.42, 0.75, 0.69)
-		[Toggle] _Foam("Foam", Float) = 1
-		[NoScaleOffset] _FoamTexture ( "    Texture", 2D ) = "white" {}
-		_FoamScale("    Scale", Range(0.01, 50.0)) = 10.0
-		_FoamWhiteColor("    White Foam Color", Color) = (1.0, 1.0, 1.0, 1.0)
-		_FoamBubbleColor("    Bubble Foam Color", Color) = (0.64, 0.83, 0.82, 1.0)
-		_ShorelineFoamMinDepth("    Shoreline Foam Min Depth", Range(0.01, 5.0)) = 0.27
-		_WaveFoamFeather("    Wave Foam Feather", Range(0.001,1.0)) = 0.32
-		_WaveFoamBubblesCoverage("    Wave Foam Bubbles Coverage", Range(0.0,5.0)) = 0.95
+		[NoScaleOffset] _FoamTexture ( "Foam Texture", 2D ) = "white" {}
+		_FoamScale("Foam Scale", Range(0.01, 50.0)) = 10.0
+		_FoamWhiteColor("Foam White Foam Color", Color) = (1.0, 1.0, 1.0, 1.0)
+		_FoamBubbleColor("Foam Bubble Foam Color", Color) = (0.64, 0.83, 0.82, 1.0)
+		_ShorelineFoamMinDepth("Foam Shoreline Foam Min Depth", Range(0.01, 5.0)) = 0.27
+		_WaveFoamFeather("Foam Wave Foam Feather", Range(0.001,1.0)) = 0.32
+		_WaveFoamBubblesCoverage("Foam Wave Foam Bubbles Coverage", Range(0.0,5.0)) = 0.95
 		[Toggle] _Foam3DLighting("Foam 3D Lighting", Float) = 1
 		_WaveFoamLightScale("    Light Scale", Range(0.0, 2.0)) = 0.7
 		_WaveFoamNormalStrength("    Normals Strength", Range(0.0, 30.0)) = 3.5
@@ -51,16 +50,14 @@ Shader "Ocean/Ocean"
 		_CausticsDistortionStrength("    Distortion Strength", Range(0.0, 0.25)) = 0.075
 		_FresnelPower("Fresnel Power", Range(0.0, 20.0)) = 3.0
 		[NoScaleOffset] _Skybox ("Skybox", CUBE) = "" {}
-		[Toggle] _PlanarReflections("Planar Reflections", Float) = 1
 		[Toggle] _ProceduralSky("Procedural Sky", Float) = 0
 		[HDR] _SkyBase("    Base", Color) = (1.0, 1.0, 1.0, 1.0)
 		[HDR] _SkyTowardsSun("    Towards Sun", Color) = (1.0, 1.0, 1.0, 1.0)
 		_SkyDirectionality("    Directionality", Range(0.0, 0.99)) = 1.0
 		[HDR] _SkyAwayFromSun("    Away From Sun", Color) = (1.0, 1.0, 1.0, 1.0)
-		[Toggle] _Shadows("Shadows", Float) = 1
-		_DiffuseShadow("    Diffuse Colour", Color) = (0.2, 0.05, 0.05, 1.0)
-		_SubSurfaceShallowColShadow("    Shallow Colour", Color) = (0.42, 0.75, 0.69)
-		[Toggle] _ApplyFlowToNormals("Apply Flow To Normals (Experimental)", Float) = 0
+		_DiffuseShadow("Shadow Diffuse Colour", Color) = (0.2, 0.05, 0.05, 1.0)
+		_SubSurfaceShallowColShadow("Shadow Shallow Colour", Color) = (0.42, 0.75, 0.69)
+		[Toggle] _Flow("Enable", Float) = 0
 		[Enum(CullMode)] _CullMode("Cull Mode", Int) = 2
 		[Toggle] _DebugDisableShapeTextures("Debug Disable Shape Textures", Float) = 0
 		[Toggle] _DebugVisualiseShapeSample("Debug Visualise Shape Sample", Float) = 0
@@ -107,7 +104,7 @@ Shader "Ocean/Ocean"
 				#pragma shader_feature _FOAM3DLIGHTING_ON
 				#pragma shader_feature _PLANARREFLECTIONS_ON
 				#pragma shader_feature _PROCEDURALSKY_ON
-				#pragma shader_feature _APPLYFLOWTONORMALS_ON
+				#pragma shader_feature _FLOW_ON
 				#pragma shader_feature _SHADOWS_ON
 
 				#pragma shader_feature _DEBUGDISABLESHAPETEXTURES_ON
@@ -132,7 +129,7 @@ Shader "Ocean/Ocean"
 				struct v2f
 				{
 					float4 vertex : SV_POSITION;
-					#if _APPLYFLOWTONORMALS_ON
+					#if _FLOW_ON
 					half2 flow : TEXCOORD2;
 					#endif
 					half4 n_shadow : TEXCOORD1;
@@ -171,7 +168,7 @@ Shader "Ocean/Ocean"
 					o.n_shadow = half4(0., 0., 0., 0.);
 					o.foam_screenPos.x = 0.;
 
-					#if _APPLYFLOWTONORMALS_ON
+					#if _FLOW_ON
 					o.flow = half2(0., 0.);
 					#endif
 
@@ -194,7 +191,7 @@ Shader "Ocean/Ocean"
 						SampleFoam(_LD_Sampler_Foam_0, uv_0, wt_0, o.foam_screenPos.x);
 						#endif
 
-						#if _APPLYFLOWTONORMALS_ON
+						#if _FLOW_ON
 						SampleFlow(_LD_Sampler_Flow_0, uv_0, wt_0, o.flow);
 						#endif
 
@@ -218,7 +215,7 @@ Shader "Ocean/Ocean"
 						SampleFoam(_LD_Sampler_Foam_1, uv_1, wt_1, o.foam_screenPos.x);
 						#endif
 
-						#if _APPLYFLOWTONORMALS_ON
+						#if _FLOW_ON
 						SampleFlow(_LD_Sampler_Flow_1, uv_1, wt_1, o.flow);
 						#endif
 
@@ -301,7 +298,7 @@ Shader "Ocean/Ocean"
 					half3 n_geom = normalize(half3(i.n_shadow.x, 1., i.n_shadow.y));
 					half3 n_pixel = n_geom;
 					#if _APPLYNORMALMAPPING_ON
-					#if _APPLYFLOWTONORMALS_ON
+					#if _FLOW_ON
 					ApplyNormalMapsWithFlow(i.lodAlpha_worldXZUndisplaced_oceanDepth.yz, i.flow, i.lodAlpha_worldXZUndisplaced_oceanDepth.x, n_pixel);
 					#else
 					n_pixel.xz += SampleNormalMaps(i.lodAlpha_worldXZUndisplaced_oceanDepth.yz, i.lodAlpha_worldXZUndisplaced_oceanDepth.x);
@@ -313,11 +310,11 @@ Shader "Ocean/Ocean"
 					half3 bubbleCol = (half3)0.;
 					#if _FOAM_ON
 					half4 whiteFoamCol;
-					#if !_APPLYFLOWTONORMALS_ON
+					#if !_FLOW_ON
 					ComputeFoam(i.foam_screenPos.x, i.lodAlpha_worldXZUndisplaced_oceanDepth.yz, i.worldPos.xz, n_pixel, pixelZ, sceneZ, view, lightDir, shadow.y, bubbleCol, whiteFoamCol);
 					#else
 					ComputeFoamWithFlow(i.flow, i.foam_screenPos.x, i.lodAlpha_worldXZUndisplaced_oceanDepth.yz, i.worldPos.xz, n_pixel, pixelZ, sceneZ, view, lightDir, shadow.y, bubbleCol, whiteFoamCol);
-					#endif // _APPLYFLOWTONORMALS_ON
+					#endif // _FLOW_ON
 					#endif // _FOAM_ON
 
 					// Compute color of ocean - in-scattered light + refracted scene
@@ -338,7 +335,7 @@ Shader "Ocean/Ocean"
 					col = lerp(col.rgb, i.debugtint, 0.5);
 					#endif
 					#if _DEBUGVISUALISEFLOW_ON
-					#if _APPLYFLOWTONORMALS_ON
+					#if _FLOW_ON
 					col.rg = lerp(col.rg, i.flow.xy, 0.5);
 					#endif
 					#endif

--- a/src/unity/Assets/Crest/Shaders/Simulation/Resources/ShapeSimFoam.shader
+++ b/src/unity/Assets/Crest/Shaders/Simulation/Resources/ShapeSimFoam.shader
@@ -60,7 +60,7 @@ Shader "Ocean/Shape/Sim/Foam"
 				{
 					float4 uv = float4(i.uv_uv_lastframe.xy, 0., 0.);
 					float4 uv_lastframe = float4(i.uv_uv_lastframe.zw, 0., 0.);
-					// #if _APPLYFLOWTONORMALS_ON
+					// #if _FLOW_ON
 					half4 velocity = half4(tex2Dlod(_LD_Sampler_Flow_1, uv).xy, 0., 0.);
 					half foam = tex2Dlod(_LD_Sampler_Foam_0, uv_lastframe
 						- ((_SimDeltaTime * i.invRes) * velocity)


### PR DESCRIPTION
@Midda-C @dizzy2003 @holdingjason

Up until now there were checkboxes for features driven by code such as foam, shadowing, planar reflections, and possibly more things in the future. This has a number of disadvantages:

* Duplicate config - if you forget to turn it on on the material then the feature won't appear and it won't give any warnings or errors
* Duplicate config - you may disable a feature on the ocean renderer but accidentally leave it turned on on the ocean mat, and pay for a feature you're not using
* If you want a feature on in some situations and off in others, the current workflow suggests that you need to duplicate the ocean material, which can create a lot of duplicated data which creates maintenance issues.

In this PR the above mentioned features are driven directly by code. When the LodData activates it will turn on the feature on the ocean material, and when it deactivates it will turn it off. The options for these are no longer exposed in the inspector, and switched off by default.

The switches that are now removed used to serve as group headers in the parameter list, and I faked an indentation using spaces for params in each group. Now that some of these are gone, I found the Header attribute which gives proper headings:

![image](https://user-images.githubusercontent.com/939901/46584296-98d81c00-ca59-11e8-8e32-903e1bcca775.png)

Impact - Should be small. If you have any ocean mat variants that purely turn on/off the above features, this may mean you can remove the dupes. The param names should all be the same so there should be no required data to move forward.

If you guys have any thoughts etc let me know, otherwise I'll get it merged.
