### PR TITLE
Complete and reintegrate underwater reflection shader

### DIFF
--- a/src/unity/Assets/Crest/Shaders/Ocean.shader
+++ b/src/unity/Assets/Crest/Shaders/Ocean.shader
@@ -387,12 +387,10 @@ Shader "Ocean/Ocean"
 						ApplyReflectionUnderwater(view, n_pixel, lightDir, shadow.y, i.foam_screenPos.yzzw, scatterCol, col);
 					}
 					else
+					#endif
 					{
 						ApplyReflectionSky(view, n_pixel, lightDir, shadow.y, i.foam_screenPos.yzzw, col);
 					}
-					#else
-					ApplyReflectionSky(view, n_pixel, lightDir, shadow.y, i.foam_screenPos.yzzw, col);
-					#endif
 
 					// Override final result with white foam - bubbles on surface
 					#if _FOAM_ON

--- a/src/unity/Assets/Crest/Shaders/Ocean.shader
+++ b/src/unity/Assets/Crest/Shaders/Ocean.shader
@@ -37,6 +37,8 @@ Shader "Ocean/Ocean"
 
 		[Header(Reflection Environment)]
 		_FresnelPower("Fresnel Power", Range(0.0, 20.0)) = 3.0
+		_RefractiveIndexOfAir("Refractive Index of Air", Range(1.0, 2.0)) = 1.0
+		_RefractiveIndexOfWater("Refractive Index of Water", Range(1.0, 2.0)) = 1.333
 		[NoScaleOffset] _Skybox ("Skybox", CUBE) = "" {}
 		[Toggle] _PlanarReflections("Planar Reflections", Float) = 0
 
@@ -379,7 +381,18 @@ Shader "Ocean/Ocean"
 					half3 col = OceanEmission(view, n_pixel, lightDir, i.grabPos, pixelZ, uvDepth, sceneZ, sceneZ01, bubbleCol, _Normals, _CameraDepthTexture, underwater, scatterCol);
 
 					// Light that reflects off water surface
+					#if _UNDERWATER_ON
+					if (underwater)
+					{
+						ApplyReflectionUnderwater(view, n_pixel, lightDir, shadow.y, i.foam_screenPos.yzzw, scatterCol, col);
+					}
+					else
+					{
+						ApplyReflectionSky(view, n_pixel, lightDir, shadow.y, i.foam_screenPos.yzzw, col);
+					}
+					#else
 					ApplyReflectionSky(view, n_pixel, lightDir, shadow.y, i.foam_screenPos.yzzw, col);
+					#endif
 
 					// Override final result with white foam - bubbles on surface
 					#if _FOAM_ON

--- a/src/unity/Assets/Crest/Shaders/OceanEmission.hlsl
+++ b/src/unity/Assets/Crest/Shaders/OceanEmission.hlsl
@@ -209,14 +209,15 @@ half3 OceanEmission(in const half3 i_view, in const half3 i_n_pixel, in const fl
 #if _CAUSTICS_ON
 		ApplyCaustics(i_view, i_lightDir, i_sceneZ, i_normals, sceneColour);
 #endif
+		alpha = 1.0 - exp(-_DepthFogDensity.xyz * depthFogDistance);
 	}
 	else
 	{
 		sceneColour = tex2D(_BackgroundTexture, uvBackgroundRefract).rgb;
 		depthFogDistance = i_pixelZ;
+		// keep alpha at 0 as UnderwaterReflection shader handles the blend
+		// appropriately when looking at water from below
 	}
-
-	alpha = 1.0 - exp(-_DepthFogDensity.xyz * depthFogDistance);
 
 	// blend from water colour to the scene colour
 	col = lerp(sceneColour, col, alpha);

--- a/src/unity/Assets/Crest/Shaders/OceanReflection.hlsl
+++ b/src/unity/Assets/Crest/Shaders/OceanReflection.hlsl
@@ -4,9 +4,9 @@
 uniform half3 _SkyBase, _SkyAwayFromSun, _SkyTowardsSun;
 uniform half _SkyDirectionality;
 
-half3 SkyProceduralDP(half3 refl, half3 lightDir)
+half3 SkyProceduralDP(in const half3 i_refl, in const half3 i_lightDir)
 {
-	half dp = dot(refl, lightDir);
+	half dp = dot(i_refl, i_lightDir);
 
 	if (dp > _SkyDirectionality)
 	{
@@ -22,15 +22,19 @@ half3 SkyProceduralDP(half3 refl, half3 lightDir)
 #if _PLANARREFLECTIONS_ON
 uniform sampler2D _ReflectionTex;
 
-half3 PlanarReflection(half3 refl, half4 i_screenPos, half3 n_pixel)
+half3 PlanarReflection(in const half4 i_screenPos, in const half3 i_n_pixel)
 {
-	i_screenPos.xy += n_pixel.xz;
+	half4 screenPos = i_screenPos;
+	screenPos.xy += i_n_pixel.xz;
 	return tex2Dproj(_ReflectionTex, UNITY_PROJ_COORD(i_screenPos)).xyz;
 }
 #endif // _PLANARREFLECTIONS_ON
 
 
 uniform half _FresnelPower;
+uniform float  _RefractiveIndexOfAir;
+uniform float  _RefractiveIndexOfWater;
+
 
 #if _COMPUTEDIRECTIONALLIGHT_ON
 uniform half _DirectionalLightFallOff;
@@ -41,63 +45,64 @@ uniform half _DirectionalLightBoost;
 uniform samplerCUBE _Skybox;
 #endif
 
-void ApplyReflectionSky(half3 view, half3 n_pixel, half3 lightDir, half shadow, half4 i_screenPos, inout half3 col)
+float CalculateFresnelReflectionCoeffecient(float cosTheta)
+{
+	// Fresnel calculated using Schlick's approximation
+	// See: http://www.cs.virginia.edu/~jdl/bib/appearance/analytic%20models/schlick94b.pdf
+	// reflectance at facing angle
+	float R_0 = (_RefractiveIndexOfAir - _RefractiveIndexOfWater) / (_RefractiveIndexOfAir + _RefractiveIndexOfWater); R_0 *= R_0;
+	const float R_theta = R_0 + (1.0 - R_0) * pow(1.0 - cosTheta, _FresnelPower);
+	return R_theta;
+}
+
+void ApplyReflectionSky(in const half3 i_view, in const half3 i_n_pixel, in const half3 i_lightDir, in const half i_shadow, in const half4 i_screenPos, inout half3 io_col)
 {
 	// Reflection
-	half3 refl = reflect(-view, n_pixel);
+	half3 refl = reflect(-i_view, i_n_pixel);
 	half3 skyColour;
 
 #if _PLANARREFLECTIONS_ON
-	skyColour = PlanarReflection(refl, i_screenPos, n_pixel);
+	skyColour = PlanarReflection(i_screenPos, i_n_pixel);
 #elif _PROCEDURALSKY_ON
-	skyColour = SkyProceduralDP(refl, lightDir);
+	skyColour = SkyProceduralDP(refl, i_lightDir);
 #else
 	skyColour = texCUBE(_Skybox, refl).rgb;
 #endif
 
 	// Add primary light to boost it
 #if _COMPUTEDIRECTIONALLIGHT_ON
-	skyColour += pow(max(0., dot(refl, lightDir)), _DirectionalLightFallOff) * _DirectionalLightBoost * _LightColor0 * shadow;
+	skyColour += pow(max(0., dot(refl, i_lightDir)), _DirectionalLightFallOff) * _DirectionalLightBoost * _LightColor0 * i_shadow;
 #endif
 
 	// Fresnel
-	const float IOR_AIR = 1.0;
-	const float IOR_WATER = 1.33;
-	// reflectance at facing angle
-	float R_0 = (IOR_AIR - IOR_WATER) / (IOR_AIR + IOR_WATER); R_0 *= R_0;
-	// schlick's approximation
-	float R_theta = R_0 + (1.0 - R_0) * pow(1.0 - max(dot(n_pixel, view), 0.), _FresnelPower);
-	col = lerp(col, skyColour, R_theta);
+	float R_theta = CalculateFresnelReflectionCoeffecient(max(dot(i_n_pixel, i_view), 0.));
+	io_col = lerp(io_col, skyColour, R_theta);
 }
 
-// disabling for now as this is WIP
-#if 0
-void ApplyReflectionUnderwater(half3 view, half3 n_pixel, half3 lightDir, half shadow, half4 i_screenPos, inout half3 col)
+#if _UNDERWATER_ON
+void ApplyReflectionUnderwater(in const half3 i_view, in const half3 i_n_pixel, in const half3 i_lightDir, in const half i_shadow, in const half4 i_screenPos, half3 scatterCol, inout half3 io_col)
 {
-	// Reflection
-	half3 refl = reflect(-view, n_pixel);
+	const half3 underwaterColor = scatterCol;
+	// The the angle of outgoing light from water's surface
+	// (whether refracted form outside or internally reflected)
+	const float cosOutgoingAngle = max(dot(i_n_pixel, i_view), 0.);
 
-	// TODO: calculate what will be reflected back from the deep
-	half3 underwaterColor = half3(0, 0, .01);
-
-	// Total Internal Reflection
-	const float IOR_AIR = 1.0;
-	const float IOR_WATER = 1.33;
-	const float CRITICAL_ANGLE = asin(IOR_AIR/IOR_WATER);
-
-	float angle = acos(dot(n_pixel, view));
-
-	float transitionDelta = .1;
-	// a hack to interpolate from refraction to TIR.
-	float lerpFactor = pow(((angle + transitionDelta) - CRITICAL_ANGLE)/transitionDelta, 5);
-	// TODO: look at http://habib.wikidot.com/projected-grid-ocean-shader-full-html-version#toc9
-	if (angle > CRITICAL_ANGLE)
+	// calculate the amount of incident light from the outside world (io_col)
 	{
-		col = underwaterColor;
+		// have to calculate the incident angle of incoming light to water
+		// surface based on how it would be refracted so as to hit the camera
+		const float cosIncomingAngle = cos(asin((_RefractiveIndexOfWater * sin(acos(cosOutgoingAngle)))/_RefractiveIndexOfAir));
+		const float reflectionCoefficient = CalculateFresnelReflectionCoeffecient(cosIncomingAngle);
+		io_col = io_col * (1 - reflectionCoefficient);
+		io_col = max(io_col, 0);
 	}
-	else if (angle > CRITICAL_ANGLE - transitionDelta)
+
+	// calculate the amount of light reflected from below the water
 	{
-		col = lerp(col, underwaterColor, lerpFactor);
+		// angle of incident is angle of reflection
+		const float cosIncomingAngle = cosOutgoingAngle;
+		const float reflectionCoefficient = CalculateFresnelReflectionCoeffecient(cosIncomingAngle);
+		io_col = io_col + (underwaterColor * reflectionCoefficient);
 	}
 }
 #endif


### PR DESCRIPTION
The previously WIP underwater shader is now much more physically based:
![high FOV view of underwater](https://user-images.githubusercontent.com/10348641/50739341-c22e5280-11d6-11e9-8390-5caebeba21be.png)

Here's a screenshot of [Snell's Window](https://en.wikipedia.org/wiki/Snell%27s_window) in effect:

![Screenshot of Snell's Window](https://user-images.githubusercontent.com/10348641/50739327-885d4c00-11d6-11e9-8e39-08f3c3267910.png)

The `OceanReflection.hlsl` file is also cleaned-up in general to bring it in-line with the rest of the code base, and the refractive indices of air and water are now exposed and adjustable in the Ocean shader.
