### PR TITLE
this fixes zillion if Underwater material instances creation

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
@@ -18,6 +18,7 @@ namespace Crest
         Mesh _mesh;
         Renderer _rend;
         MaterialPropertyBlock _mpb;
+        private Material _lastmaterial;
 
         // Cache these off to support regenerating ocean surface
         int _lodIndex = -1;
@@ -31,7 +32,7 @@ namespace Crest
         {
             _rend = GetComponent<Renderer>();
             _mesh = GetComponent<MeshFilter>().mesh;
-
+            _lastmaterial = _rend.material;
             _boundsLocal = _mesh.bounds;
 
             _reflectionTexId = Shader.PropertyToID("_ReflectionTex");
@@ -81,9 +82,10 @@ namespace Crest
             // Depth texture is used by ocean shader for transparency/depth fog, and for fading out foam at shoreline.
             _currentCamera.depthTextureMode |= DepthTextureMode.Depth;
 
-            if (_rend.material != OceanRenderer.Instance.OceanMaterial)
+            if (_lastmaterial != OceanRenderer.Instance.OceanMaterial)
             {
-                _rend.material = OceanRenderer.Instance.OceanMaterial;
+                _lastmaterial = OceanRenderer.Instance.OceanMaterial;
+                _rend.material = _lastmaterial;
             }
 
             // per instance data


### PR DESCRIPTION
fixes new material instance creation every frame,
resulting slowdown and crash after few minutes.
material property surprising