### PR TITLE
Abstract materials and mpbs to make CS port easier

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/PropertyWrapper.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/PropertyWrapper.cs
@@ -19,7 +19,7 @@ namespace Crest
         void SetInt(int param, int value);
     }
 
-    public struct PropertyWrapperMaterial : IPropertyWrapper
+    public class PropertyWrapperMaterial : IPropertyWrapper
     {
         public PropertyWrapperMaterial(Material target) { _target = target; }
         public PropertyWrapperMaterial(Shader shader) { _target = new Material(shader); }
@@ -33,7 +33,7 @@ namespace Crest
         public Material material { get { return _target; }}
         private Material _target;
     }
-    public struct PropertyWrapperMPB : IPropertyWrapper
+    public class PropertyWrapperMPB : IPropertyWrapper
     {
         public PropertyWrapperMPB(MaterialPropertyBlock target) { _target = target; }
         public void SetFloat(int param, float value) { _target.SetFloat(param, value); }

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/PropertyWrapper.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/PropertyWrapper.cs
@@ -13,20 +13,37 @@ namespace Crest
     {
         void SetFloat(int param, float value);
         void SetVector(int param, Vector4 value);
+        void SetVectorArray(int param, Vector4[] value);
         void SetTexture(int param, Texture value);
+        void SetMatrix(int param, Matrix4x4 matrix);
+        void SetInt(int param, int value);
     }
-    public class PropertyWrapperMaterial : IPropertyWrapper
+
+    public struct PropertyWrapperMaterial : IPropertyWrapper
     {
+        public PropertyWrapperMaterial(Material target) { _target = target; }
+        public PropertyWrapperMaterial(Shader shader) { _target = new Material(shader); }
         public void SetFloat(int param, float value) { _target.SetFloat(param, value); }
         public void SetTexture(int param, Texture value) { _target.SetTexture(param, value); }
         public void SetVector(int param, Vector4 value) { _target.SetVector(param, value); }
-        public Material _target;
+        public void SetVectorArray(int param, Vector4[] value) { _target.SetVectorArray(param, value); }
+        public void SetMatrix(int param, Matrix4x4 value) { _target.SetMatrix(param, value); }
+        public void SetInt(int param, int value) { _target.SetInt(param, value); }
+
+        public Material material { get { return _target; }}
+        private Material _target;
     }
-    public class PropertyWrapperMPB : IPropertyWrapper
+    public struct PropertyWrapperMPB : IPropertyWrapper
     {
+        public PropertyWrapperMPB(MaterialPropertyBlock target) { _target = target; }
         public void SetFloat(int param, float value) { _target.SetFloat(param, value); }
         public void SetTexture(int param, Texture value) { _target.SetTexture(param, value); }
         public void SetVector(int param, Vector4 value) { _target.SetVector(param, value); }
-        public MaterialPropertyBlock _target;
+        public void SetVectorArray(int param, Vector4[] value) { _target.SetVectorArray(param, value); }
+        public void SetMatrix(int param, Matrix4x4 value) { _target.SetMatrix(param, value); }
+        public void SetInt(int param, int value) { _target.SetInt(param, value); }
+
+        public MaterialPropertyBlock materialPropertyBlock { get { return _target; }}
+        private MaterialPropertyBlock _target;
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/RenderAlphaOnSurface.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/RenderAlphaOnSurface.cs
@@ -19,6 +19,8 @@ namespace Crest
         Mesh _mesh;
         Bounds _boundsLocal;
 
+        static int sp_InstanceData = Shader.PropertyToID("_InstanceData");
+
         private void Start()
         {
             _rend = GetComponent<Renderer>();
@@ -64,7 +66,7 @@ namespace Crest
                 // blend furthest normals scale in/out to avoid pop, if scale could reduce
                 bool needToBlendOutNormals = idx == lodCount - 1 && OceanRenderer.Instance.ScaleCouldDecrease;
                 float farNormalsWeight = needToBlendOutNormals ? OceanRenderer.Instance.ViewerAltitudeLevelAlpha : 1f;
-                _mpb.SetVector(Shader.PropertyToID("_InstanceData"), new Vector4(meshScaleLerp, farNormalsWeight, idx));
+                _mpb.SetVector(sp_InstanceData, new Vector4(meshScaleLerp, farNormalsWeight, idx));
 
                 _rend.SetPropertyBlock(_mpb.materialPropertyBlock);
             }

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/RenderAlphaOnSurface.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/RenderAlphaOnSurface.cs
@@ -14,7 +14,7 @@ namespace Crest
     {
         public bool _drawBounds = false;
 
-        MaterialPropertyBlock _mpb;
+        PropertyWrapperMPB _mpb;
         Renderer _rend;
         Mesh _mesh;
         Bounds _boundsLocal;
@@ -44,12 +44,12 @@ namespace Crest
 
             if (idx > -1)
             {
-                if (_mpb == null)
+                if (_mpb.materialPropertyBlock == null)
                 {
-                    _mpb = new MaterialPropertyBlock();
+                    _mpb = new PropertyWrapperMPB(new MaterialPropertyBlock());
                 }
 
-                _rend.GetPropertyBlock(_mpb);
+                _rend.GetPropertyBlock(_mpb.materialPropertyBlock);
 
                 var lodCount = OceanRenderer.Instance.CurrentLodCount;
                 var ldaw = OceanRenderer.Instance._lodDataAnimWaves;
@@ -64,9 +64,9 @@ namespace Crest
                 // blend furthest normals scale in/out to avoid pop, if scale could reduce
                 bool needToBlendOutNormals = idx == lodCount - 1 && OceanRenderer.Instance.ScaleCouldDecrease;
                 float farNormalsWeight = needToBlendOutNormals ? OceanRenderer.Instance.ViewerAltitudeLevelAlpha : 1f;
-                _mpb.SetVector("_InstanceData", new Vector4(meshScaleLerp, farNormalsWeight, idx));
+                _mpb.SetVector(Shader.PropertyToID("_InstanceData"), new Vector4(meshScaleLerp, farNormalsWeight, idx));
 
-                _rend.SetPropertyBlock(_mpb);
+                _rend.SetPropertyBlock(_mpb.materialPropertyBlock);
             }
 
             LateUpdateBounds();

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/RenderAlphaOnSurface.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/RenderAlphaOnSurface.cs
@@ -44,7 +44,7 @@ namespace Crest
 
             if (idx > -1)
             {
-                if (_mpb.materialPropertyBlock == null)
+                if (_mpb == null)
                 {
                     _mpb = new PropertyWrapperMPB(new MaterialPropertyBlock());
                 }

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
@@ -34,6 +34,8 @@ namespace Crest
         PropertyWrapperMPB _mpb;
         Renderer _rend;
 
+        static int sp_HeightOffset = Shader.PropertyToID("_HeightOffset");
+
         private void Start()
         {
             _rend = GetComponent<Renderer>();
@@ -126,7 +128,7 @@ namespace Crest
                     LodDataMgrShadow.BindNull(0, _mpb);
                 }
 
-                _mpb.SetFloat(Shader.PropertyToID("_HeightOffset"), heightOffset);
+                _mpb.SetFloat(sp_HeightOffset, heightOffset);
 
                 _rend.SetPropertyBlock(_mpb.materialPropertyBlock);
             }

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
@@ -31,7 +31,7 @@ namespace Crest
         // how many vertical edges to add to curtain geometry
         const int GEOM_HORIZ_DIVISIONS = 64;
 
-        MaterialPropertyBlock _mpb;
+        PropertyWrapperMPB _mpb;
         Renderer _rend;
 
         private void Start()
@@ -99,11 +99,11 @@ namespace Crest
                 }
 
                 // Assign lod0 shape - trivial but bound every frame because lod transform comes from here
-                if (_mpb == null)
+                if (_mpb.materialPropertyBlock == null)
                 {
-                    _mpb = new MaterialPropertyBlock();
+                    _mpb = new PropertyWrapperMPB(new MaterialPropertyBlock());
                 }
-                _rend.GetPropertyBlock(_mpb);
+                _rend.GetPropertyBlock(_mpb.materialPropertyBlock);
 
                 // Underwater rendering uses displacements for intersecting the waves with the near plane, and ocean depth/shadows for ScatterColour()
                 OceanRenderer.Instance._lodDataAnimWaves.BindResultData(0, 0, _mpb);
@@ -126,9 +126,9 @@ namespace Crest
                     LodDataMgrShadow.BindNull(0, _mpb);
                 }
 
-                _mpb.SetFloat("_HeightOffset", heightOffset);
+                _mpb.SetFloat(Shader.PropertyToID("_HeightOffset"), heightOffset);
 
-                _rend.SetPropertyBlock(_mpb);
+                _rend.SetPropertyBlock(_mpb.materialPropertyBlock);
             }
         }
 

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
@@ -99,7 +99,7 @@ namespace Crest
                 }
 
                 // Assign lod0 shape - trivial but bound every frame because lod transform comes from here
-                if (_mpb.materialPropertyBlock == null)
+                if (_mpb == null)
                 {
                     _mpb = new PropertyWrapperMPB(new MaterialPropertyBlock());
                 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
@@ -96,28 +96,14 @@ namespace Crest
             _scaleDifferencePow2 = Mathf.RoundToInt(ratio_l2);
         }
 
-        protected PropertyWrapperMaterial _pwMat = new PropertyWrapperMaterial();
-        protected PropertyWrapperMPB _pwMPB = new PropertyWrapperMPB();
-
-        public void BindResultData(int lodIdx, int shapeSlot, Material properties)
+        public void BindResultData(int lodIdx, int shapeSlot, IPropertyWrapper properties)
         {
-            _pwMat._target = properties;
-            BindData(lodIdx, shapeSlot, _pwMat, DataTexture(lodIdx), true, ref OceanRenderer.Instance._lods[lodIdx]._renderData);
-            _pwMat._target = null;
+            BindData(lodIdx, shapeSlot, properties, DataTexture(lodIdx), true, ref OceanRenderer.Instance._lods[lodIdx]._renderData);
         }
 
-        public void BindResultData(int lodIdx, int shapeSlot, MaterialPropertyBlock properties)
+        public void BindResultData(int lodIdx, int shapeSlot, IPropertyWrapper properties, bool blendOut)
         {
-            _pwMPB._target = properties;
-            BindData(lodIdx, shapeSlot, _pwMPB, DataTexture(lodIdx), true, ref OceanRenderer.Instance._lods[lodIdx]._renderData);
-            _pwMPB._target = null;
-        }
-
-        public void BindResultData(int lodIdx, int shapeSlot, Material properties, bool blendOut)
-        {
-            _pwMat._target = properties;
-            BindData(lodIdx, shapeSlot, _pwMat, DataTexture(lodIdx), blendOut, ref OceanRenderer.Instance._lods[lodIdx]._renderData);
-            _pwMat._target = null;
+            BindData(lodIdx, shapeSlot, properties, DataTexture(lodIdx), blendOut, ref OceanRenderer.Instance._lods[lodIdx]._renderData);
         }
 
         protected virtual void BindData(int lodIdx, int shapeSlot, IPropertyWrapper properties, Texture applyData, bool blendOut, ref LodTransform.RenderData renderData)

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrDynWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrDynWaves.cs
@@ -31,6 +31,12 @@ namespace Crest
         bool[] _active;
         public bool SimActive(int lodIdx) { return _active[lodIdx]; }
 
+        static int sp_HorizDisplace = Shader.PropertyToID("_HorizDisplace");
+        static int sp_DisplaceClamp = Shader.PropertyToID("_DisplaceClamp");
+        static int sp_Damping = Shader.PropertyToID("_Damping");
+        static int sp_Gravity = Shader.PropertyToID("_Gravity");
+        static int sp_LaplacianAxisX = Shader.PropertyToID("_LaplacianAxisX");
+
         protected override void InitData()
         {
             base.InitData();
@@ -63,19 +69,19 @@ namespace Crest
 
         public void BindCopySettings(PropertyWrapperMaterial target)
         {
-            target.SetFloat(Shader.PropertyToID("_HorizDisplace"), Settings._horizDisplace);
-            target.SetFloat(Shader.PropertyToID("_DisplaceClamp"), Settings._displaceClamp);
+            target.SetFloat(sp_HorizDisplace, Settings._horizDisplace);
+            target.SetFloat(sp_DisplaceClamp, Settings._displaceClamp);
         }
 
         protected override void SetAdditionalSimParams(int lodIdx, PropertyWrapperMaterial simMaterial)
         {
             base.SetAdditionalSimParams(lodIdx, simMaterial);
 
-            simMaterial.SetFloat(Shader.PropertyToID("_Damping"), Settings._damping);
-            simMaterial.SetFloat(Shader.PropertyToID("_Gravity"), OceanRenderer.Instance.Gravity);
+            simMaterial.SetFloat(sp_Damping, Settings._damping);
+            simMaterial.SetFloat(sp_Gravity, OceanRenderer.Instance.Gravity);
 
             float laplacianKernelAngle = _rotateLaplacian ? Mathf.PI * 2f * Random.value : 0f;
-            simMaterial.SetVector(Shader.PropertyToID("_LaplacianAxisX"), new Vector2(Mathf.Cos(laplacianKernelAngle), Mathf.Sin(laplacianKernelAngle)));
+            simMaterial.SetVector(sp_LaplacianAxisX, new Vector2(Mathf.Cos(laplacianKernelAngle), Mathf.Sin(laplacianKernelAngle)));
 
             // assign sea floor depth - to slot 1 current frame data. minor bug here - this depth will actually be from the previous frame,
             // because the depth is scheduled to render just before the animated waves, and this sim happens before animated waves.

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrDynWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrDynWaves.cs
@@ -61,21 +61,21 @@ namespace Crest
             return true;
         }
 
-        public void BindCopySettings(Material target)
+        public void BindCopySettings(PropertyWrapperMaterial target)
         {
-            target.SetFloat("_HorizDisplace", Settings._horizDisplace);
-            target.SetFloat("_DisplaceClamp", Settings._displaceClamp);
+            target.SetFloat(Shader.PropertyToID("_HorizDisplace"), Settings._horizDisplace);
+            target.SetFloat(Shader.PropertyToID("_DisplaceClamp"), Settings._displaceClamp);
         }
 
-        protected override void SetAdditionalSimParams(int lodIdx, Material simMaterial)
+        protected override void SetAdditionalSimParams(int lodIdx, PropertyWrapperMaterial simMaterial)
         {
             base.SetAdditionalSimParams(lodIdx, simMaterial);
 
-            simMaterial.SetFloat("_Damping", Settings._damping);
-            simMaterial.SetFloat("_Gravity", OceanRenderer.Instance.Gravity);
+            simMaterial.SetFloat(Shader.PropertyToID("_Damping"), Settings._damping);
+            simMaterial.SetFloat(Shader.PropertyToID("_Gravity"), OceanRenderer.Instance.Gravity);
 
             float laplacianKernelAngle = _rotateLaplacian ? Mathf.PI * 2f * Random.value : 0f;
-            simMaterial.SetVector("_LaplacianAxisX", new Vector2(Mathf.Cos(laplacianKernelAngle), Mathf.Sin(laplacianKernelAngle)));
+            simMaterial.SetVector(Shader.PropertyToID("_LaplacianAxisX"), new Vector2(Mathf.Cos(laplacianKernelAngle), Mathf.Sin(laplacianKernelAngle)));
 
             // assign sea floor depth - to slot 1 current frame data. minor bug here - this depth will actually be from the previous frame,
             // because the depth is scheduled to render just before the animated waves, and this sim happens before animated waves.
@@ -137,11 +137,7 @@ namespace Crest
         {
             return ParamIdSampler(slot);
         }
-        public static void BindNull(int shapeSlot, Material properties)
-        {
-            properties.SetTexture(ParamIdSampler(shapeSlot), Texture2D.blackTexture);
-        }
-        public static void BindNull(int shapeSlot, MaterialPropertyBlock properties)
+        public static void BindNull(int shapeSlot, IPropertyWrapper properties)
         {
             properties.SetTexture(ParamIdSampler(shapeSlot), Texture2D.blackTexture);
         }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFlow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFlow.cs
@@ -86,11 +86,7 @@ namespace Crest
         {
             return ParamIdSampler(slot);
         }
-        public static void BindNull(int shapeSlot, Material properties)
-        {
-            properties.SetTexture(ParamIdSampler(shapeSlot), Texture2D.blackTexture);
-        }
-        public static void BindNull(int shapeSlot, MaterialPropertyBlock properties)
+        public static void BindNull(int shapeSlot, IPropertyWrapper properties)
         {
             properties.SetTexture(ParamIdSampler(shapeSlot), Texture2D.blackTexture);
         }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFoam.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFoam.cs
@@ -36,15 +36,15 @@ namespace Crest
 #endif
         }
 
-        protected override void SetAdditionalSimParams(int lodIdx, Material simMaterial)
+        protected override void SetAdditionalSimParams(int lodIdx, PropertyWrapperMaterial simMaterial)
         {
             base.SetAdditionalSimParams(lodIdx, simMaterial);
 
-            simMaterial.SetFloat("_FoamFadeRate", Settings._foamFadeRate);
-            simMaterial.SetFloat("_WaveFoamStrength", Settings._waveFoamStrength);
-            simMaterial.SetFloat("_WaveFoamCoverage", Settings._waveFoamCoverage);
-            simMaterial.SetFloat("_ShorelineFoamMaxDepth", Settings._shorelineFoamMaxDepth);
-            simMaterial.SetFloat("_ShorelineFoamStrength", Settings._shorelineFoamStrength);
+            simMaterial.SetFloat(Shader.PropertyToID("_FoamFadeRate"), Settings._foamFadeRate);
+            simMaterial.SetFloat(Shader.PropertyToID("_WaveFoamStrength"), Settings._waveFoamStrength);
+            simMaterial.SetFloat(Shader.PropertyToID("_WaveFoamCoverage"), Settings._waveFoamCoverage);
+            simMaterial.SetFloat(Shader.PropertyToID("_ShorelineFoamMaxDepth"), Settings._shorelineFoamMaxDepth);
+            simMaterial.SetFloat(Shader.PropertyToID("_ShorelineFoamStrength"), Settings._shorelineFoamStrength);
 
             // assign animated waves - to slot 1 current frame data
             OceanRenderer.Instance._lodDataAnimWaves.BindResultData(lodIdx, 1, simMaterial);

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFoam.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFoam.cs
@@ -24,6 +24,12 @@ namespace Crest
             return settings;
         }
 
+        static int sp_FoamFadeRate = Shader.PropertyToID("_FoamFadeRate");
+        static int sp_WaveFoamStrength = Shader.PropertyToID("_WaveFoamStrength");
+        static int sp_WaveFoamCoverage = Shader.PropertyToID("_WaveFoamCoverage");
+        static int sp_ShorelineFoamMaxDepth = Shader.PropertyToID("_ShorelineFoamMaxDepth");
+        static int sp_ShorelineFoamStrength = Shader.PropertyToID("_ShorelineFoamStrength");
+
         protected override void Start()
         {
             base.Start();
@@ -40,11 +46,11 @@ namespace Crest
         {
             base.SetAdditionalSimParams(lodIdx, simMaterial);
 
-            simMaterial.SetFloat(Shader.PropertyToID("_FoamFadeRate"), Settings._foamFadeRate);
-            simMaterial.SetFloat(Shader.PropertyToID("_WaveFoamStrength"), Settings._waveFoamStrength);
-            simMaterial.SetFloat(Shader.PropertyToID("_WaveFoamCoverage"), Settings._waveFoamCoverage);
-            simMaterial.SetFloat(Shader.PropertyToID("_ShorelineFoamMaxDepth"), Settings._shorelineFoamMaxDepth);
-            simMaterial.SetFloat(Shader.PropertyToID("_ShorelineFoamStrength"), Settings._shorelineFoamStrength);
+            simMaterial.SetFloat(sp_FoamFadeRate, Settings._foamFadeRate);
+            simMaterial.SetFloat(sp_WaveFoamStrength, Settings._waveFoamStrength);
+            simMaterial.SetFloat(sp_WaveFoamCoverage, Settings._waveFoamCoverage);
+            simMaterial.SetFloat(sp_ShorelineFoamMaxDepth, Settings._shorelineFoamMaxDepth);
+            simMaterial.SetFloat(sp_ShorelineFoamStrength, Settings._shorelineFoamStrength);
 
             // assign animated waves - to slot 1 current frame data
             OceanRenderer.Instance._lodDataAnimWaves.BindResultData(lodIdx, 1, simMaterial);

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrPersistent.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrPersistent.cs
@@ -15,7 +15,7 @@ namespace Crest
         protected readonly int MAX_SIM_STEPS = 4;
 
         RenderTexture[] _sources;
-        Material[,] _renderSimMaterial;
+        PropertyWrapperMaterial[,] _renderSimMaterial;
 
         protected abstract string ShaderSim { get; }
 
@@ -30,13 +30,13 @@ namespace Crest
 
         void CreateMaterials(int lodCount)
         {
-            _renderSimMaterial = new Material[MAX_SIM_STEPS, lodCount];
+            _renderSimMaterial = new PropertyWrapperMaterial[MAX_SIM_STEPS, lodCount];
             var shader = Shader.Find(ShaderSim);
             for (int stepi = 0; stepi < MAX_SIM_STEPS; stepi++)
             {
                 for (int i = 0; i < lodCount; i++)
                 {
-                    _renderSimMaterial[stepi, i] = new Material(shader);
+                    _renderSimMaterial[stepi, i] = new PropertyWrapperMaterial(shader);
                 }
             }
         }
@@ -63,16 +63,13 @@ namespace Crest
             }
         }
 
-        public void BindSourceData(int lodIdx, int shapeSlot, Material properties, bool paramsOnly, bool usePrevTransform)
+        public void BindSourceData(int lodIdx, int shapeSlot, PropertyWrapperMaterial properties, bool paramsOnly, bool usePrevTransform)
         {
-            _pwMat._target = properties;
-
             var rd = usePrevTransform ?
                 OceanRenderer.Instance._lods[lodIdx]._renderDataPrevFrame.Validate(BuildCommandBufferBase._lastUpdateFrame - Time.frameCount, this)
                 : OceanRenderer.Instance._lods[lodIdx]._renderData.Validate(0, this);
 
-            BindData(lodIdx, shapeSlot, _pwMat, paramsOnly ? Texture2D.blackTexture : (Texture)_sources[lodIdx], true, ref rd);
-            _pwMat._target = null;
+            BindData(lodIdx, shapeSlot, properties, paramsOnly ? Texture2D.blackTexture : (Texture)_sources[lodIdx], true, ref rd);
         }
 
         public abstract void GetSimSubstepData(float frameDt, out int numSubsteps, out float substepDt);
@@ -95,10 +92,10 @@ namespace Crest
 
                 for (var lodIdx = lodCount - 1; lodIdx >= 0; lodIdx--)
                 {
-                    _renderSimMaterial[stepi, lodIdx].SetFloat("_SimDeltaTime", substepDt);
-                    _renderSimMaterial[stepi, lodIdx].SetFloat("_SimDeltaTimePrev", _substepDtPrevious);
+                    _renderSimMaterial[stepi, lodIdx].SetFloat(Shader.PropertyToID("_SimDeltaTime"), substepDt);
+                    _renderSimMaterial[stepi, lodIdx].SetFloat(Shader.PropertyToID("_SimDeltaTimePrev"), _substepDtPrevious);
 
-                    _renderSimMaterial[stepi, lodIdx].SetFloat("_GridSize", OceanRenderer.Instance._lods[lodIdx]._renderData._texelWidth);
+                    _renderSimMaterial[stepi, lodIdx].SetFloat(Shader.PropertyToID("_GridSize"), OceanRenderer.Instance._lods[lodIdx]._renderData._texelWidth);
 
                     // compute which lod data we are sampling source data from. if a scale change has happened this can be any lod up or down the chain.
                     // this is only valid on the first update step, after that the scale src/target data are in the right places.
@@ -125,7 +122,7 @@ namespace Crest
                         buf.SetRenderTarget(rt, rt.depthBuffer);
                     }
 
-                    buf.DrawMesh(FullScreenQuad(), Matrix4x4.identity, _renderSimMaterial[stepi, lodIdx]);
+                    buf.DrawMesh(FullScreenQuad(), Matrix4x4.identity, _renderSimMaterial[stepi, lodIdx].material);
 
                     SubmitDraws(lodIdx, buf);
                 }
@@ -149,7 +146,7 @@ namespace Crest
         /// <summary>
         /// Set any sim-specific shader params.
         /// </summary>
-        protected virtual void SetAdditionalSimParams(int lodIdx, Material simMaterial)
+        protected virtual void SetAdditionalSimParams(int lodIdx, PropertyWrapperMaterial simMaterial)
         {
         }
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrPersistent.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrPersistent.cs
@@ -21,6 +21,10 @@ namespace Crest
 
         float _substepDtPrevious = 1f / 60f;
 
+        static int sp_SimDeltaTime = Shader.PropertyToID("_SimDeltaTime");
+        static int sp_SimDeltaTimePrev = Shader.PropertyToID("_SimDeltaTimePrev");
+        static int sp_GridSize = Shader.PropertyToID("_GridSize");
+
         protected override void Start()
         {
             base.Start();
@@ -92,10 +96,10 @@ namespace Crest
 
                 for (var lodIdx = lodCount - 1; lodIdx >= 0; lodIdx--)
                 {
-                    _renderSimMaterial[stepi, lodIdx].SetFloat(Shader.PropertyToID("_SimDeltaTime"), substepDt);
-                    _renderSimMaterial[stepi, lodIdx].SetFloat(Shader.PropertyToID("_SimDeltaTimePrev"), _substepDtPrevious);
+                    _renderSimMaterial[stepi, lodIdx].SetFloat(sp_SimDeltaTime, substepDt);
+                    _renderSimMaterial[stepi, lodIdx].SetFloat(sp_SimDeltaTimePrev, _substepDtPrevious);
 
-                    _renderSimMaterial[stepi, lodIdx].SetFloat(Shader.PropertyToID("_GridSize"), OceanRenderer.Instance._lods[lodIdx]._renderData._texelWidth);
+                    _renderSimMaterial[stepi, lodIdx].SetFloat(sp_GridSize, OceanRenderer.Instance._lods[lodIdx]._renderData._texelWidth);
 
                     // compute which lod data we are sampling source data from. if a scale change has happened this can be any lod up or down the chain.
                     // this is only valid on the first update step, after that the scale src/target data are in the right places.

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -56,11 +56,7 @@ namespace Crest
         {
             return ParamIdSampler(slot);
         }
-        public static void BindNull(int shapeSlot, Material properties)
-        {
-            properties.SetTexture(ParamIdSampler(shapeSlot), Texture2D.blackTexture);
-        }
-        public static void BindNull(int shapeSlot, MaterialPropertyBlock properties)
+        public static void BindNull(int shapeSlot, IPropertyWrapper properties)
         {
             properties.SetTexture(ParamIdSampler(shapeSlot), Texture2D.blackTexture);
         }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrShadow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrShadow.cs
@@ -25,6 +25,14 @@ namespace Crest
         RenderTexture[] _sources;
         PropertyWrapperMaterial[] _renderMaterial;
 
+        static int sp_CenterPos = Shader.PropertyToID("_CenterPos");
+        static int sp_Scale = Shader.PropertyToID("_Scale");
+        static int sp_CamPos = Shader.PropertyToID("_CamPos");
+        static int sp_CamForward = Shader.PropertyToID("_CamForward");
+        static int sp_JitterDiameters_CurrentFrameWeights = Shader.PropertyToID("_JitterDiameters_CurrentFrameWeights");
+        static int sp_MainCameraProjectionMatrix = Shader.PropertyToID("_MainCameraProjectionMatrix");
+        static int sp_SimDeltaTime = Shader.PropertyToID("_SimDeltaTime");
+
         SimSettingsShadow Settings { get { return OceanRenderer.Instance._simSettingsShadow; } }
         public override void UseSettings(SimSettingsBase settings) { OceanRenderer.Instance._simSettingsShadow = settings as SimSettingsShadow; }
         public override SimSettingsBase CreateDefaultSettings()
@@ -184,13 +192,13 @@ namespace Crest
                 var lt = OceanRenderer.Instance._lods[lodIdx];
 
                 lt._renderData.Validate(0, this);
-                _renderMaterial[lodIdx].SetVector(Shader.PropertyToID("_CenterPos"), lt._renderData._posSnapped);
-                _renderMaterial[lodIdx].SetVector(Shader.PropertyToID("_Scale"), lt.transform.lossyScale);
-                _renderMaterial[lodIdx].SetVector(Shader.PropertyToID("_CamPos"), OceanRenderer.Instance.Viewpoint.position);
-                _renderMaterial[lodIdx].SetVector(Shader.PropertyToID("_CamForward"), OceanRenderer.Instance.Viewpoint.forward);
-                _renderMaterial[lodIdx].SetVector(Shader.PropertyToID("_JitterDiameters_CurrentFrameWeights"), new Vector4(Settings._jitterDiameterSoft, Settings._jitterDiameterHard, Settings._currentFrameWeightSoft, Settings._currentFrameWeightHard));
-                _renderMaterial[lodIdx].SetMatrix(Shader.PropertyToID("_MainCameraProjectionMatrix"), _cameraMain.projectionMatrix * _cameraMain.worldToCameraMatrix);
-                _renderMaterial[lodIdx].SetFloat(Shader.PropertyToID("_SimDeltaTime"), Time.deltaTime);
+                _renderMaterial[lodIdx].SetVector(sp_CenterPos, lt._renderData._posSnapped);
+                _renderMaterial[lodIdx].SetVector(sp_Scale, lt.transform.lossyScale);
+                _renderMaterial[lodIdx].SetVector(sp_CamPos, OceanRenderer.Instance.Viewpoint.position);
+                _renderMaterial[lodIdx].SetVector(sp_CamForward, OceanRenderer.Instance.Viewpoint.forward);
+                _renderMaterial[lodIdx].SetVector(sp_JitterDiameters_CurrentFrameWeights, new Vector4(Settings._jitterDiameterSoft, Settings._jitterDiameterHard, Settings._currentFrameWeightSoft, Settings._currentFrameWeightHard));
+                _renderMaterial[lodIdx].SetMatrix(sp_MainCameraProjectionMatrix, _cameraMain.projectionMatrix * _cameraMain.worldToCameraMatrix);
+                _renderMaterial[lodIdx].SetFloat(sp_SimDeltaTime, Time.deltaTime);
 
                 // compute which lod data we are sampling previous frame shadows from. if a scale change has happened this can be any lod up or down the chain.
                 var srcDataIdx = lt.LodIndex + ScaleDifferencePow2;

--- a/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
@@ -17,7 +17,7 @@ namespace Crest
         Bounds _boundsLocal;
         Mesh _mesh;
         Renderer _rend;
-        MaterialPropertyBlock _mpb;
+        PropertyWrapperMPB _mpb;
 
         // Cache these off to support regenerating ocean surface
         int _lodIndex = -1;
@@ -87,11 +87,11 @@ namespace Crest
 
             // per instance data
 
-            if (_mpb == null)
+            if (_mpb.materialPropertyBlock == null)
             {
-                _mpb = new MaterialPropertyBlock();
+                _mpb = new PropertyWrapperMPB(new MaterialPropertyBlock());
             }
-            _rend.GetPropertyBlock(_mpb);
+            _rend.GetPropertyBlock(_mpb.materialPropertyBlock);
 
             // blend LOD 0 shape in/out to avoid pop, if the ocean might scale up later (it is smaller than its maximum scale)
             var needToBlendOutShape = _lodIndex == 0 && OceanRenderer.Instance.ScaleCouldIncrease;
@@ -100,7 +100,7 @@ namespace Crest
             // blend furthest normals scale in/out to avoid pop, if scale could reduce
             var needToBlendOutNormals = _lodIndex == _totalLodCount - 1 && OceanRenderer.Instance.ScaleCouldDecrease;
             var farNormalsWeight = needToBlendOutNormals ? OceanRenderer.Instance.ViewerAltitudeLevelAlpha : 1f;
-            _mpb.SetVector("_InstanceData", new Vector4(meshScaleLerp, farNormalsWeight, _lodIndex));
+            _mpb.SetVector(Shader.PropertyToID("_InstanceData"), new Vector4(meshScaleLerp, farNormalsWeight, _lodIndex));
 
             // geometry data
             // compute grid size of geometry. take the long way to get there - make sure we land exactly on a power of two
@@ -112,7 +112,7 @@ namespace Crest
             var pow = 1.4f; // fudge 2
             var normalScrollSpeed0 = Mathf.Pow(Mathf.Log(1f + 2f * gridSizeLodData) * mul, pow);
             var normalScrollSpeed1 = Mathf.Pow(Mathf.Log(1f + 4f * gridSizeLodData) * mul, pow);
-            _mpb.SetVector("_GeomData", new Vector4(gridSizeLodData, gridSizeGeo, normalScrollSpeed0, normalScrollSpeed1));
+            _mpb.SetVector(Shader.PropertyToID("_GeomData"), new Vector4(gridSizeLodData, gridSizeGeo, normalScrollSpeed0, normalScrollSpeed1));
 
             // assign lod data to ocean shader
             var ldaws = OceanRenderer.Instance._lodDataAnimWaves;
@@ -151,9 +151,9 @@ namespace Crest
             // cause here might be imprecision or numerical issues at ocean tile boundaries, although
             // i'm not sure why cracks are not visible in this case.
             var heightOffset = OceanRenderer.Instance.ViewerHeightAboveWater;
-            _mpb.SetFloat("_ForceUnderwater", heightOffset < -2f ? 1f : 0f);
+            _mpb.SetFloat(Shader.PropertyToID("_ForceUnderwater"), heightOffset < -2f ? 1f : 0f);
 
-            _rend.SetPropertyBlock(_mpb);
+            _rend.SetPropertyBlock(_mpb.materialPropertyBlock);
 
             if (_drawRenderBounds)
             {

--- a/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
@@ -87,7 +87,7 @@ namespace Crest
 
             // per instance data
 
-            if (_mpb.materialPropertyBlock == null)
+            if (_mpb == null)
             {
                 _mpb = new PropertyWrapperMPB(new MaterialPropertyBlock());
             }

--- a/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
@@ -25,15 +25,16 @@ namespace Crest
         int _lodDataResolution = 256;
         int _geoDownSampleFactor = 1;
 
-        int _reflectionTexId = -1;
+        static int sp_ReflectionTex = Shader.PropertyToID("_ReflectionTex");
+        static int sp_InstanceData = Shader.PropertyToID("_InstanceData");
+        static int sp_GeomData = Shader.PropertyToID("_GeomData");
+        static int sp_ForceUnderwater = Shader.PropertyToID("_ForceUnderwater");
 
         void Start()
         {
             _rend = GetComponent<Renderer>();
             _mesh = GetComponent<MeshFilter>().mesh;
             _boundsLocal = _mesh.bounds;
-
-            _reflectionTexId = Shader.PropertyToID("_ReflectionTex");
 
             UpdateMeshBounds();
         }
@@ -100,7 +101,7 @@ namespace Crest
             // blend furthest normals scale in/out to avoid pop, if scale could reduce
             var needToBlendOutNormals = _lodIndex == _totalLodCount - 1 && OceanRenderer.Instance.ScaleCouldDecrease;
             var farNormalsWeight = needToBlendOutNormals ? OceanRenderer.Instance.ViewerAltitudeLevelAlpha : 1f;
-            _mpb.SetVector(Shader.PropertyToID("_InstanceData"), new Vector4(meshScaleLerp, farNormalsWeight, _lodIndex));
+            _mpb.SetVector(sp_InstanceData, new Vector4(meshScaleLerp, farNormalsWeight, _lodIndex));
 
             // geometry data
             // compute grid size of geometry. take the long way to get there - make sure we land exactly on a power of two
@@ -112,7 +113,7 @@ namespace Crest
             var pow = 1.4f; // fudge 2
             var normalScrollSpeed0 = Mathf.Pow(Mathf.Log(1f + 2f * gridSizeLodData) * mul, pow);
             var normalScrollSpeed1 = Mathf.Pow(Mathf.Log(1f + 4f * gridSizeLodData) * mul, pow);
-            _mpb.SetVector(Shader.PropertyToID("_GeomData"), new Vector4(gridSizeLodData, gridSizeGeo, normalScrollSpeed0, normalScrollSpeed1));
+            _mpb.SetVector(sp_GeomData, new Vector4(gridSizeLodData, gridSizeGeo, normalScrollSpeed0, normalScrollSpeed1));
 
             // assign lod data to ocean shader
             var ldaws = OceanRenderer.Instance._lodDataAnimWaves;
@@ -139,11 +140,11 @@ namespace Crest
             var reflTex = OceanPlanarReflection.GetRenderTexture(_currentCamera.targetDisplay);
             if (reflTex)
             {
-                _mpb.SetTexture(_reflectionTexId, reflTex);
+                _mpb.SetTexture(sp_ReflectionTex, reflTex);
             }
             else
             {
-                _mpb.SetTexture(_reflectionTexId, Texture2D.blackTexture);
+                _mpb.SetTexture(sp_ReflectionTex, Texture2D.blackTexture);
             }
 
             // Hack - due to SV_IsFrontFace occasionally coming through as true for backfaces,
@@ -151,7 +152,7 @@ namespace Crest
             // cause here might be imprecision or numerical issues at ocean tile boundaries, although
             // i'm not sure why cracks are not visible in this case.
             var heightOffset = OceanRenderer.Instance.ViewerHeightAboveWater;
-            _mpb.SetFloat(Shader.PropertyToID("_ForceUnderwater"), heightOffset < -2f ? 1f : 0f);
+            _mpb.SetFloat(sp_ForceUnderwater, heightOffset < -2f ? 1f : 0f);
 
             _rend.SetPropertyBlock(_mpb.materialPropertyBlock);
 

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -41,6 +41,16 @@ namespace Crest
         // Shader to be used to render evaluate Gerstner waves for each LOD
         Shader _waveShader;
 
+        static int sp_TwoPiOverWavelengths = Shader.PropertyToID("_TwoPiOverWavelengths");
+        static int sp_Amplitudes = Shader.PropertyToID("_Amplitudes");
+        static int sp_WaveDirX = Shader.PropertyToID("_WaveDirX");
+        static int sp_WaveDirZ = Shader.PropertyToID("_WaveDirZ");
+        static int sp_Phases = Shader.PropertyToID("_Phases");
+        static int sp_ChopAmps = Shader.PropertyToID("_ChopAmps");
+        static int sp_NumInBatch = Shader.PropertyToID("_NumInBatch");
+        static int sp_AttenuationInShallows = Shader.PropertyToID("_AttenuationInShallows");
+        static int sp_NumWaveVecs = Shader.PropertyToID("_NumWaveVecs");
+
         // IMPORTANT - this mirrors the constant with the same name in ShapeGerstnerBatch.shader, both must be updated together!
         const int BATCH_SIZE = 32;
 
@@ -295,17 +305,17 @@ namespace Crest
             }
 
             // apply the data to the shape property
-            property.SetVectorArray(Shader.PropertyToID("_TwoPiOverWavelengths"), UpdateBatchScratchData._twoPiOverWavelengthsBatch);
-            property.SetVectorArray(Shader.PropertyToID("_Amplitudes"), UpdateBatchScratchData._ampsBatch);
-            property.SetVectorArray(Shader.PropertyToID("_WaveDirX"), UpdateBatchScratchData._waveDirXBatch);
-            property.SetVectorArray(Shader.PropertyToID("_WaveDirZ"), UpdateBatchScratchData._waveDirZBatch);
-            property.SetVectorArray(Shader.PropertyToID("_Phases"), UpdateBatchScratchData._phasesBatch);
-            property.SetVectorArray(Shader.PropertyToID("_ChopAmps"), UpdateBatchScratchData._chopAmpsBatch);
-            property.SetFloat(Shader.PropertyToID("_NumInBatch"), numInBatch);
-            property.SetFloat(Shader.PropertyToID("_AttenuationInShallows"), OceanRenderer.Instance._simSettingsAnimatedWaves.AttenuationInShallows);
+            property.SetVectorArray(sp_TwoPiOverWavelengths, UpdateBatchScratchData._twoPiOverWavelengthsBatch);
+            property.SetVectorArray(sp_Amplitudes, UpdateBatchScratchData._ampsBatch);
+            property.SetVectorArray(sp_WaveDirX, UpdateBatchScratchData._waveDirXBatch);
+            property.SetVectorArray(sp_WaveDirZ, UpdateBatchScratchData._waveDirZBatch);
+            property.SetVectorArray(sp_Phases, UpdateBatchScratchData._phasesBatch);
+            property.SetVectorArray(sp_ChopAmps, UpdateBatchScratchData._chopAmpsBatch);
+            property.SetFloat(sp_NumInBatch, numInBatch);
+            property.SetFloat(sp_AttenuationInShallows, OceanRenderer.Instance._simSettingsAnimatedWaves.AttenuationInShallows);
 
             int numVecs = (numInBatch + 3) / 4;
-            property.SetInt(Shader.PropertyToID("_NumWaveVecs"), numVecs);
+            property.SetInt(sp_NumWaveVecs, numVecs);
             OceanRenderer.Instance._lodDataAnimWaves.BindResultData(lodIdx, 0, property);
 
             if (OceanRenderer.Instance._lodDataSeaDepths)


### PR DESCRIPTION
In order to make the transition to Compute Shaders as smooth as possible, we are staging the process so that they will initially be implemented with the same structure (and alongside) the existing shaders. As compute shaders do not use Materials for parameter initialisation, we need to roll our own system which can share an interface with the same abstraction that the existing materials use.