### PR TITLE
Store depths simply instead of relative to a baseline

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -8,7 +8,7 @@ using UnityEngine.Rendering;
 namespace Crest
 {
     /// <summary>
-    /// Renders relative depth of ocean floor, by rendering the relative height of tagged objects from top down.
+    /// Renders depth of the ocean (height of sea level above ocean floor), by rendering the relative height of tagged objects from top down.
     /// </summary>
     public class LodDataMgrSeaFloorDepth : LodDataMgr
     {
@@ -33,7 +33,7 @@ namespace Crest
             for (int lodIdx = OceanRenderer.Instance.CurrentLodCount - 1; lodIdx >= 0; lodIdx--)
             {
                 buf.SetRenderTarget(_targets[lodIdx]);
-                buf.ClearRenderTarget(false, true, Color.black);
+                buf.ClearRenderTarget(false, true, Color.white * 1000f);
 
                 SubmitDraws(lodIdx, buf);
             }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -132,8 +132,8 @@ namespace Crest
                 _camDepthCache.targetTexture = _cacheTexture;
                 _camDepthCache.cullingMask = layerMask;
                 _camDepthCache.clearFlags = CameraClearFlags.SolidColor;
-                // 0 means '0m above very deep sea floor'
-                _camDepthCache.backgroundColor = Color.black;
+                // Clear to 'very deep'
+                _camDepthCache.backgroundColor = Color.white * 1000f;
                 _camDepthCache.enabled = false;
                 _camDepthCache.allowMSAA = false;
                 // I'd prefer to destroy the cam object, but I found sometimes (on first start of editor) it will fail to render.

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -63,6 +63,11 @@ namespace Crest
             {
                 Debug.LogWarning("Ocean depth cache transform scale is small and will capture a small area of the world. Is this intended?", this);
             }
+
+            if(_forceAlwaysUpdateDebug)
+            {
+                Debug.LogWarning("Note: Force Always Update Debug option is enabled on depth cache " + gameObject.name, this);
+            }
         }
 
 #if UNITY_EDITOR

--- a/crest/Assets/Crest/Crest/Shaders/Ocean.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Ocean.shader
@@ -266,7 +266,7 @@ Shader "Crest/Ocean"
 				o.flow_shadow = half4(0., 0., 0., 0.);
 				o.foam_screenPos.x = 0.;
 
-				o.lodAlpha_worldXZUndisplaced_oceanDepth.w = 0.;
+				o.lodAlpha_worldXZUndisplaced_oceanDepth.w = CREST_OCEAN_DEPTH_BASELINE;
 				
 				// Sample shape textures - always lerp between 2 LOD scales, so sample two textures
 
@@ -292,7 +292,7 @@ Shader "Crest/Ocean"
 					#endif
 
 					#if _SUBSURFACESHALLOWCOLOUR_ON
-					SampleSeaFloorHeightAboveBaseline(_LD_Sampler_SeaFloorDepth_0, uv_0, wt_0, o.lodAlpha_worldXZUndisplaced_oceanDepth.w);
+					SampleSeaDepth(_LD_Sampler_SeaFloorDepth_0, uv_0, wt_0, o.lodAlpha_worldXZUndisplaced_oceanDepth.w);
 					#endif
 
 					#if _SHADOWS_ON
@@ -316,16 +316,13 @@ Shader "Crest/Ocean"
 					#endif
 
 					#if _SUBSURFACESHALLOWCOLOUR_ON
-					SampleSeaFloorHeightAboveBaseline(_LD_Sampler_SeaFloorDepth_1, uv_1, wt_1, o.lodAlpha_worldXZUndisplaced_oceanDepth.w);
+					SampleSeaDepth(_LD_Sampler_SeaFloorDepth_1, uv_1, wt_1, o.lodAlpha_worldXZUndisplaced_oceanDepth.w);
 					#endif
 
 					#if _SHADOWS_ON
 					SampleShadow(_LD_Sampler_Shadow_1, uv_1, wt_1, o.flow_shadow.zw);
 					#endif
 				}
-
-				// Convert height above -1000m to depth below surface
-				o.lodAlpha_worldXZUndisplaced_oceanDepth.w = CREST_OCEAN_DEPTH_BASELINE - o.lodAlpha_worldXZUndisplaced_oceanDepth.w;
 
 				// Foam can saturate
 				o.foam_screenPos.x = saturate(o.foam_screenPos.x);

--- a/crest/Assets/Crest/Crest/Shaders/OceanEmission.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanEmission.hlsl
@@ -65,9 +65,8 @@ half3 ScatterColour(
 		//    so just approximate by sampling at the camera position.
 		// this used to sample LOD1 but that doesnt work in last LOD, the data will be missing.
 		const float2 uv_0 = LD_0_WorldToUV(i_cameraPos.xz);
-		float seaFloorHeightAboveBaseline = 0.0;
-		SampleSeaFloorHeightAboveBaseline(_LD_Sampler_SeaFloorDepth_0, uv_0, 1.0, seaFloorHeightAboveBaseline);
-		depth = CREST_OCEAN_DEPTH_BASELINE - seaFloorHeightAboveBaseline;
+		depth = CREST_OCEAN_DEPTH_BASELINE;
+		SampleSeaDepth(_LD_Sampler_SeaFloorDepth_0, uv_0, 1.0, depth);
 		waveHeight = 0.0;
 
 #if _SHADOWS_ON

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/AnimWavesGerstnerBatch.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/AnimWavesGerstnerBatch.shader
@@ -79,7 +79,7 @@ Shader "Crest/Inputs/Animated Waves/Gerstner Batch"
 				const half4 oneMinusAttenuation = (half4)1.0 - (half4)_AttenuationInShallows;
 
 				// sample ocean depth (this render target should 1:1 match depth texture, so UVs are trivial)
-				const half depth = CREST_OCEAN_DEPTH_BASELINE - tex2D(_LD_Sampler_SeaFloorDepth_0, input.uv).x;
+				const half depth = tex2D(_LD_Sampler_SeaFloorDepth_0, input.uv).x;
 				half3 result = (half3)0.0;
 
 				// gerstner computation is vectorized - processes 4 wave components at once

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepths.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepths.shader
@@ -9,7 +9,7 @@ Shader "Crest/Inputs/Depth/Ocean Depth From Geometry"
 	{
 		Pass
 		{
-			BlendOp Max
+			BlendOp Min
 
 			CGPROGRAM
 			#pragma vertex Vert
@@ -36,11 +36,7 @@ Shader "Crest/Inputs/Depth/Ocean Depth From Geometry"
 
 				float altitude = mul(unity_ObjectToWorld, float4(input.positionOS, 1.0)).y;
 
-				// Depth is altitude above 1000m below sea level. This is because '0' needs to signify deep water.
-				// I originally used a simple bias in the depth texture but it would still produce shallow water outside
-				// the biggest LOD texture where the depth would evaluate to 0 in the ocean vert shader, so i've transformed
-				// 0 to mean deep below the surface.
-				o.depth = altitude - (_OceanCenterPosWorld.y - CREST_OCEAN_DEPTH_BASELINE);
+				o.depth = _OceanCenterPosWorld.y - altitude;
 
 				return o;
 			}

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCache.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCache.shader
@@ -17,7 +17,7 @@ Shader "Crest/Inputs/Depth/Cached Depths"
 			// Min blending to take the min of all depths. Similar in spirit to zbuffer'd visibility when viewing from top down.
 			// To confuse matters further, ocean depth is now more like 'sea floor altitude' - a height above a deep water value,
 			// so values are increasing in Y and we need to take the MAX of all depths.
-			BlendOp Max
+			BlendOp Min
 
 			CGPROGRAM
 			#pragma vertex Vert

--- a/crest/Assets/Crest/Crest/Shaders/OceanLODData.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanLODData.hlsl
@@ -24,8 +24,7 @@
 LOD_DATA( 0 )
 LOD_DATA( 1 )
 
-// Bias ocean floor depth so that default (0) values in texture are not interpreted as shallow and generating foam everywhere
-#define CREST_OCEAN_DEPTH_BASELINE 1000.
+#define CREST_OCEAN_DEPTH_BASELINE -1000.0
 
 // Conversions for world space from/to UV space
 float2 LD_WorldToUV(in float2 i_samplePos, in float2 i_centerPos, in float i_res, in float i_texelSize)
@@ -77,9 +76,9 @@ void SampleFlow(in sampler2D i_oceanFlowSampler, float2 i_uv, in float i_wt, ino
 	io_flow += i_wt * tex2Dlod(i_oceanFlowSampler, uv).xy;
 }
 
-void SampleSeaFloorHeightAboveBaseline(in sampler2D i_oceanDepthSampler, float2 i_uv, in float i_wt, inout half io_oceanDepth)
+void SampleSeaDepth(in sampler2D i_oceanDepthSampler, float2 i_uv, in float i_wt, inout half io_oceanDepth)
 {
-	io_oceanDepth += i_wt * (tex2Dlod(i_oceanDepthSampler, float4(i_uv, 0., 0.)).x);
+	io_oceanDepth += i_wt * (tex2Dlod(i_oceanDepthSampler, float4(i_uv, 0.0, 0.0)).x - CREST_OCEAN_DEPTH_BASELINE);
 }
 
 void SampleShadow(in sampler2D i_oceanShadowSampler, float2 i_uv, in float i_wt, inout half2 io_shadow)

--- a/crest/Assets/Crest/Crest/Shaders/Resources/UpdateDynWaves.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/UpdateDynWaves.shader
@@ -127,8 +127,8 @@ Shader "Hidden/Crest/Simulation/Update Dynamic Waves"
 				// eventually break. i model "Deep" water, but then simply ramp down waves in non-deep water with a linear multiplier.
 				// http://hyperphysics.phy-astr.gsu.edu/hbase/Waves/watwav2.html
 				// http://hyperphysics.phy-astr.gsu.edu/hbase/watwav.html#c1
-				float waterSignedDepth = CREST_OCEAN_DEPTH_BASELINE - tex2D(_LD_Sampler_SeaFloorDepth_1, input.uv).x;
-				float depthMul = 1.0 - (1.0 - saturate(2.0 * waterSignedDepth / wavelength)) * dt * 2.0;
+				float waterDepth = tex2D(_LD_Sampler_SeaFloorDepth_1, input.uv).x;
+				float depthMul = 1.0 - (1.0 - saturate(2.0 * waterDepth / wavelength)) * dt * 2.0;
 				ftp *= depthMul;
 				ft *= depthMul;
 

--- a/crest/Assets/Crest/Crest/Shaders/Resources/UpdateFoam.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/UpdateFoam.shader
@@ -105,8 +105,8 @@ Shader "Hidden/Crest/Simulation/Update Foam"
 
 				// add foam in shallow water. use the displaced position to ensure we add foam where world objects are.
 				float4 uv_1_displaced = float4(LD_1_WorldToUV(input.positionWS_XZ + disp.xz), 0.0, 1.0);
-				float signedOceanDepth = CREST_OCEAN_DEPTH_BASELINE - tex2Dlod(_LD_Sampler_SeaFloorDepth_1, uv_1_displaced).x + disp.y;
-				foam += _ShorelineFoamStrength * _SimDeltaTime * saturate(1.0 - signedOceanDepth / _ShorelineFoamMaxDepth);
+				float waterDepth = tex2Dlod(_LD_Sampler_SeaFloorDepth_1, uv_1_displaced).x + disp.y;
+				foam += _ShorelineFoamStrength * _SimDeltaTime * saturate(1.0 - waterDepth / _ShorelineFoamMaxDepth);
 
 				return foam;
 			}


### PR DESCRIPTION
The depths simply represent water depth (not relative ot some deep baseline)  and now the depths can be visualised/debugged directly

![image](https://user-images.githubusercontent.com/939901/57655782-98df6200-75ce-11e9-8ddb-29b159db4416.png)

This makes the code simpler/better and the system less complex.
