### PR TITLE
Make geometry ocean depth cache shader optional

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -25,7 +25,18 @@ namespace Crest
         private const string ENABLE_GEOMETRY_SHADER_KEYWORD = "_ENABLE_GEOMETRY_SHADER";
 
         private static bool UseGeometryShader { get {
-            return SystemInfo.graphicsDeviceType != UnityEngine.Rendering.GraphicsDeviceType.Metal;
+            // Only use geometry shader if target device supports it.
+            // See https://docs.unity3d.com/2018.1/Documentation/Manual/SL-ShaderCompileTargets.html
+            // See https://docs.unity3d.com/ScriptReference/SystemInfo-graphicsShaderLevel.html
+            if (SystemInfo.graphicsDeviceType == UnityEngine.Rendering.GraphicsDeviceType.Metal)
+            {
+                return false;
+            }
+            if(SystemInfo.graphicsShaderLevel <= 35 || SystemInfo.graphicsShaderLevel == 45)
+            {
+                return false;
+            }
+            return true;
         }}
 
         public static string ShaderName { get {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -28,7 +28,13 @@ namespace Crest
             // Only use geometry shader if target device supports it.
             // See https://docs.unity3d.com/2018.1/Documentation/Manual/SL-ShaderCompileTargets.html
             // See https://docs.unity3d.com/ScriptReference/SystemInfo-graphicsShaderLevel.html
-            if (SystemInfo.graphicsDeviceType == UnityEngine.Rendering.GraphicsDeviceType.Metal)
+#if PLATFORM_ANDROID
+            if(SystemInfo.graphicsDeviceType == GraphicsDeviceType.Vulkan)
+            {
+                return false;
+            }
+#endif
+            if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.Metal)
             {
                 return false;
             }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -121,7 +121,7 @@ namespace Crest
                 _drawCacheQuad.transform.localEulerAngles = 90f * Vector3.right;
                 _drawCacheQuad.AddComponent<RegisterSeaFloorDepthInput>();
                 var qr = _drawCacheQuad.GetComponent<Renderer>();
-                qr.material = new Material(Shader.Find("Crest/Inputs/Depth/Cached Depths"));
+                qr.material = new Material(Shader.Find(LodDataMgrSeaFloorDepth.ShaderName));
                 qr.material.mainTexture = _cacheTexture;
                 qr.enabled = false;
             }

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCache.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCache.shader
@@ -2,8 +2,9 @@
 
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
+
 // Draw cached depths into current frame ocean depth data
-Shader "Crest/Inputs/Depth/Cached Depths"
+Shader "Crest/Inputs/Depth/Cached Depths Geometry"
 {
 	Properties
 	{
@@ -20,73 +21,16 @@ Shader "Crest/Inputs/Depth/Cached Depths"
 			BlendOp Min
 
 			CGPROGRAM
+			#pragma multi_compile_local __ _ENABLE_GEOMETRY_SHADER
 			#pragma vertex Vert
-			#pragma geometry Geometry
 			#pragma fragment Frag
 
-			#include "UnityCG.cginc"
-			#include "../../OceanLodData.hlsl"
+			#define SlicedVaryings Varyings
+			#include "OceanDepthsCacheCommon.hlsl"
 
-			sampler2D _MainTex;
-			float4 _MainTex_ST;
-			int _CurrentLodCount;
-			float4x4 _SliceViewProjMatrices[MAX_LOD_COUNT];
-
-			struct Attributes
+			float4 ObjectToPosition(float3 positionOS)
 			{
-				float3 positionOS : POSITION;
-				float2 uv : TEXCOORD0;
-			};
-
-			struct Varyings
-			{
-				float4 positionWS : SV_POSITION;
-				float2 uv : TEXCOORD0;
-			};
-
-			struct SlicedVaryings
-			{
-				float4 positionCS : SV_POSITION;
-				float2 uv : TEXCOORD0;
-				uint sliceIndex : SV_RenderTargetArrayIndex;
-			};
-
-			Varyings Vert(Attributes input)
-			{
-				Varyings o;
-				o.positionWS = mul(unity_ObjectToWorld, float4(input.positionOS, 1));
-				o.uv = TRANSFORM_TEX(input.uv, _MainTex);
-				return o;
-			}
-
-			float4 WorldToClipPos(float4 positionWS, uint sliceIndex)
-			{
-				return mul(_SliceViewProjMatrices[sliceIndex], positionWS);
-			}
-
-			[maxvertexcount(MAX_LOD_COUNT * 3)]
-			void Geometry(
-				triangle Varyings input[3],
-				inout TriangleStream<SlicedVaryings> outStream
-			)
-			{
-				SlicedVaryings output;
-				for(int sliceIndex = 0; sliceIndex < _CurrentLodCount; sliceIndex++)
-				{
-					output.sliceIndex = sliceIndex;
-					for(int vertex = 0; vertex < 3; vertex++)
-					{
-						output.positionCS = WorldToClipPos(input[vertex].positionWS, sliceIndex);
-						output.uv = input[vertex].uv;
-						outStream.Append(output);
-					}
-					outStream.RestartStrip();
-				}
-			}
-
-			half4 Frag(SlicedVaryings input) : SV_Target
-			{
-				return half4(tex2D(_MainTex, input.uv).x, 0.0, 0.0, 0.0);
+				return UnityObjectToClipPos(positionOS);
 			}
 			ENDCG
 		}

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCacheCommon.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCacheCommon.hlsl
@@ -1,0 +1,33 @@
+#include "UnityCG.cginc"
+#include "../../OceanLodData.hlsl"
+
+sampler2D _MainTex;
+float4 _MainTex_ST;
+int _CurrentLodCount;
+float4 ObjectToPosition(float3 objectPosition);
+
+struct Attributes
+{
+	float3 positionOS : POSITION;
+	float2 uv : TEXCOORD0;
+};
+
+struct Varyings
+{
+	float4 position : SV_POSITION;
+	float2 uv : TEXCOORD0;
+};
+
+
+Varyings Vert(Attributes input)
+{
+	Varyings output;
+	output.position = ObjectToPosition(input.positionOS);
+	output.uv = TRANSFORM_TEX(input.uv, _MainTex);
+	return output;
+}
+
+half4 Frag(SlicedVaryings input) : SV_Target
+{
+	return half4(tex2D(_MainTex, input.uv).x, 0.0, 0.0, 0.0);
+}

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCacheCommon.hlsl.meta
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCacheCommon.hlsl.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 5ec8ee7f26050144481a3f94d1f19cc8
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCacheGeometry.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCacheGeometry.shader
@@ -1,0 +1,70 @@
+﻿// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+
+// Draw cached depths into current frame ocean depth data
+Shader "Crest/Inputs/Depth/Cached Depths"
+{
+	Properties
+	{
+		_MainTex ("Texture", 2D) = "white" {}
+	}
+
+	SubShader
+	{
+		Pass
+		{
+			// Min blending to take the min of all depths. Similar in spirit to zbuffer'd visibility when viewing from top down.
+			// To confuse matters further, ocean depth is now more like 'sea floor altitude' - a height above a deep water value,
+			// so values are increasing in Y and we need to take the MAX of all depths.
+			BlendOp Min
+
+			CGPROGRAM
+			#pragma vertex Vert
+ 			#pragma geometry Geometry
+			#pragma fragment Frag
+
+			struct SlicedVaryings
+			{
+				float4 position : SV_POSITION;
+				float2 uv : TEXCOORD0;
+				uint sliceIndex : SV_RenderTargetArrayIndex;
+			};
+			#include "OceanDepthsCacheCommon.hlsl"
+
+			float4x4 _SliceViewProjMatrices[MAX_LOD_COUNT];
+			float4 ObjectToPosition(float3 positionOS)
+			{
+				return mul(unity_ObjectToWorld, float4(positionOS, 1));
+			}
+
+
+			float4 WorldToClipPos(float4 positionWS, uint sliceIndex)
+			{
+				return mul(_SliceViewProjMatrices[sliceIndex], positionWS);
+			}
+
+			[maxvertexcount(MAX_LOD_COUNT * 3)]
+			void Geometry(
+				triangle Varyings input[3],
+				inout TriangleStream<SlicedVaryings> outStream
+			)
+			{
+				SlicedVaryings output;
+				for(int sliceIndex = 0; sliceIndex < _CurrentLodCount; sliceIndex++)
+				{
+					output.sliceIndex = sliceIndex;
+					for(int vertex = 0; vertex < 3; vertex++)
+					{
+						output.position = WorldToClipPos(input[vertex].position, sliceIndex);
+						output.uv = input[vertex].uv;
+						outStream.Append(output);
+					}
+					outStream.RestartStrip();
+				}
+			}
+			ENDCG
+		}
+	}
+}

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCacheGeometry.shader.meta
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCacheGeometry.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 8e1653adda90c7c42818781cf74923e9
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Geometry shaders aren't supported on some platforms, so this
demonstrates that feature for those platforms where they are definetely
not supported.