### PR TITLE
Refactor/lod hierarchy

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
@@ -114,7 +114,9 @@ namespace Crest
             for (int lodIdx = 0; lodIdx < OceanRenderer.Instance.CurrentLodCount; lodIdx++)
             {
                 // NOTE: gets zeroed by unity, see https://www.alanzucconi.com/2016/10/24/arrays-shaders-unity-5-4/
-                _BindData_paramIdPosScales[lodIdx] = new Vector4(renderData[lodIdx]._posSnapped.x, renderData[lodIdx]._posSnapped.z, lt.GetLodTransform(lodIdx).lossyScale.x, 0);
+                _BindData_paramIdPosScales[lodIdx] = new Vector4(
+                    renderData[lodIdx]._posSnapped.x, renderData[lodIdx]._posSnapped.z,
+                    OceanRenderer.Instance.CalcLodScale(lodIdx), 0f);
                 _BindData_paramIdOceans[lodIdx] = new Vector4(renderData[lodIdx]._texelWidth, renderData[lodIdx]._textureRes, 1f, 1f / renderData[lodIdx]._textureRes);
             }
             properties.SetVectorArray(LodTransform.ParamIdPosScale(sourceLod), _BindData_paramIdPosScales);

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrShadow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrShadow.cs
@@ -186,7 +186,8 @@ namespace Crest
 
                 lt._renderData[lodIdx].Validate(0, this);
                 _renderProperties.SetVector(sp_CenterPos, lt._renderData[lodIdx]._posSnapped);
-                _renderProperties.SetVector(sp_Scale, lt.GetLodTransform(lodIdx).lossyScale);
+                var scale = OceanRenderer.Instance.CalcLodScale(lodIdx);
+                _renderProperties.SetVector(sp_Scale, new Vector3(scale, 1f, scale));
                 _renderProperties.SetVector(sp_CamPos, OceanRenderer.Instance.Viewpoint.position);
                 _renderProperties.SetVector(sp_CamForward, OceanRenderer.Instance.Viewpoint.forward);
                 _renderProperties.SetVector(sp_JitterDiameters_CurrentFrameWeights, new Vector4(Settings._jitterDiameterSoft, Settings._jitterDiameterHard, Settings._currentFrameWeightSoft, Settings._currentFrameWeightHard));

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodTransform.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodTransform.cs
@@ -82,16 +82,15 @@ namespace Crest
 
                 _renderDataSource[lodIdx] = _renderData[lodIdx];
 
-                var lodTransform = GetLodTransform(lodIdx);
-
-                float camOrthSize = 2f * lodTransform.lossyScale.x;
+                var lodScale = OceanRenderer.Instance.CalcLodScale(lodIdx);
+                var camOrthSize = 2f * lodScale;
 
                 // find snap period
                 _renderData[lodIdx]._textureRes = OceanRenderer.Instance.LodDataResolution;
                 _renderData[lodIdx]._texelWidth = 2f * camOrthSize / _renderData[lodIdx]._textureRes;
                 // snap so that shape texels are stationary
-                _renderData[lodIdx]._posSnapped = lodTransform.position
-                    - new Vector3(Mathf.Repeat(lodTransform.position.x, _renderData[lodIdx]._texelWidth), 0f, Mathf.Repeat(lodTransform.position.z, _renderData[lodIdx]._texelWidth));
+                _renderData[lodIdx]._posSnapped = OceanRenderer.Instance.transform.position
+                    - new Vector3(Mathf.Repeat(OceanRenderer.Instance.transform.position.x, _renderData[lodIdx]._texelWidth), 0f, Mathf.Repeat(OceanRenderer.Instance.transform.position.z, _renderData[lodIdx]._texelWidth));
 
                 _renderData[lodIdx]._frame = Time.frameCount;
 
@@ -105,7 +104,7 @@ namespace Crest
 
                 _worldToCameraMatrix[lodIdx] = CalculateWorldToCameraMatrixRHS(_renderData[lodIdx]._posSnapped + Vector3.up * 100f, Quaternion.AngleAxis(90f, Vector3.right));
 
-                _projectionMatrix[lodIdx] = Matrix4x4.Ortho(-2f * lodTransform.lossyScale.x, 2f * lodTransform.lossyScale.x, -2f * lodTransform.lossyScale.z, 2f * lodTransform.lossyScale.z, 1f, 500f);
+                _projectionMatrix[lodIdx] = Matrix4x4.Ortho(-2f * lodScale, 2f * lodScale, -2f * lodScale, 2f * lodScale, 1f, 500f);
             }
         }
 
@@ -122,7 +121,7 @@ namespace Crest
 
         public float MaxWavelength(int lodIdx)
         {
-            float oceanBaseScale = OceanRenderer.Instance.transform.lossyScale.x;
+            float oceanBaseScale = OceanRenderer.Instance.Scale;
             float maxDiameter = 4f * oceanBaseScale * Mathf.Pow(2f, lodIdx);
             float maxTexelSize = maxDiameter / OceanRenderer.Instance.LodDataResolution;
             return 2f * maxTexelSize * OceanRenderer.Instance._minTexelsPerWave;
@@ -159,11 +158,6 @@ namespace Crest
                 _renderData[lodIdx]._posSnapped -= newOrigin;
                 _renderDataSource[lodIdx]._posSnapped -= newOrigin;
             }
-        }
-
-        public Transform GetLodTransform(int lodIdx)
-        {
-            return transform.GetChild(lodIdx);
         }
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/OceanBuilder.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanBuilder.cs
@@ -211,7 +211,7 @@ namespace Crest
             for (int i = 0; i < ocean.transform.childCount; i++)
             {
                 var child = ocean.transform.GetChild(i);
-                if (child.name.StartsWith("LOD"))
+                if (child.name.StartsWith("Tile_L"))
                 {
                     child.parent = null;
                     Object.Destroy(child.gameObject);
@@ -219,16 +219,14 @@ namespace Crest
                 }
             }
 
-            int startLevel = 0;
-            for( int i = 0; i < lodCount; i++ )
+            for (int i = 0; i < lodCount; i++)
             {
                 bool biggestLOD = i == lodCount - 1;
-                GameObject nextLod = CreateLOD(ocean, i, lodCount, biggestLOD, meshInsts, lodDataResolution, geoDownSampleFactor, oceanLayer);
-                nextLod.transform.parent = ocean.transform;
+                //nextLod.transform.parent = ocean.transform;
 
                 // scale only horizontally, otherwise culling bounding box will be scaled up in y
-                float horizScale = Mathf.Pow( 2f, (float)(i + startLevel) );
-                nextLod.transform.localScale = new Vector3( horizScale, 1f, horizScale );
+                //nextLod.transform.localScale = new Vector3(horizScale, 1f, horizScale);
+                CreateLOD(ocean, i, lodCount, biggestLOD, meshInsts, lodDataResolution, geoDownSampleFactor, oceanLayer);
             }
 
 #if PROFILE_CONSTRUCTION
@@ -371,15 +369,9 @@ namespace Crest
             return mesh;
         }
 
-        static GameObject CreateLOD(OceanRenderer ocean, int lodIndex, int lodCount, bool biggestLOD, Mesh[] meshData, int lodDataResolution, int geoDownSampleFactor, int oceanLayer)
+        static void CreateLOD(OceanRenderer ocean, int lodIndex, int lodCount, bool biggestLOD, Mesh[] meshData, int lodDataResolution, int geoDownSampleFactor, int oceanLayer)
         {
-            // first create parent GameObject for the LOD level. the scale of this transform sets the size of the LOD.
-            GameObject parent = new GameObject();
-            parent.name = "LOD" + lodIndex;
-            parent.layer = oceanLayer;
-            parent.transform.parent = ocean.transform;
-            parent.transform.localPosition = Vector3.zero;
-            parent.transform.localRotation = Quaternion.identity;
+            float horizScale = Mathf.Pow(2f, lodIndex);
 
             bool generateSkirt = biggestLOD && !ocean._disableSkirt;
 
@@ -457,10 +449,10 @@ namespace Crest
                 // instantiate and place patch
                 var patch = new GameObject( string.Format( "Tile_L{0}", lodIndex ) );
                 patch.layer = oceanLayer;
-                patch.transform.parent = parent.transform;
+                patch.transform.parent = ocean.transform;
                 Vector2 pos = offsets[i];
-                patch.transform.localPosition = new Vector3( pos.x, 0f, pos.y );
-                patch.transform.localScale = Vector3.one;
+                patch.transform.localPosition = horizScale * new Vector3(pos.x, 0f, pos.y);
+                patch.transform.localScale = new Vector3(horizScale, 1f, horizScale);
 
                 patch.AddComponent<OceanChunkRenderer>().SetInstanceData(lodIndex, lodCount, lodDataResolution, geoDownSampleFactor);
                 patch.AddComponent<MeshFilter>().mesh = meshData[(int)patchTypes[i]];
@@ -511,8 +503,6 @@ namespace Crest
                         patch.transform.localRotation = Quaternion.FromToRotation( from, to );
                 }
             }
-
-            return parent;
         }
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/OceanBuilder.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanBuilder.cs
@@ -221,12 +221,7 @@ namespace Crest
 
             for (int i = 0; i < lodCount; i++)
             {
-                bool biggestLOD = i == lodCount - 1;
-                //nextLod.transform.parent = ocean.transform;
-
-                // scale only horizontally, otherwise culling bounding box will be scaled up in y
-                //nextLod.transform.localScale = new Vector3(horizScale, 1f, horizScale);
-                CreateLOD(ocean, i, lodCount, biggestLOD, meshInsts, lodDataResolution, geoDownSampleFactor, oceanLayer);
+                CreateLOD(ocean, i, lodCount, meshInsts, lodDataResolution, geoDownSampleFactor, oceanLayer);
             }
 
 #if PROFILE_CONSTRUCTION
@@ -369,11 +364,12 @@ namespace Crest
             return mesh;
         }
 
-        static void CreateLOD(OceanRenderer ocean, int lodIndex, int lodCount, bool biggestLOD, Mesh[] meshData, int lodDataResolution, int geoDownSampleFactor, int oceanLayer)
+        static void CreateLOD(OceanRenderer ocean, int lodIndex, int lodCount, Mesh[] meshData, int lodDataResolution, int geoDownSampleFactor, int oceanLayer)
         {
             float horizScale = Mathf.Pow(2f, lodIndex);
 
-            bool generateSkirt = biggestLOD && !ocean._disableSkirt;
+            bool isBiggestLOD = lodIndex == lodCount - 1;
+            bool generateSkirt = isBiggestLOD && !ocean._disableSkirt;
 
             Vector2[] offsets;
             PatchType[] patchTypes;
@@ -452,6 +448,7 @@ namespace Crest
                 patch.transform.parent = ocean.transform;
                 Vector2 pos = offsets[i];
                 patch.transform.localPosition = horizScale * new Vector3(pos.x, 0f, pos.y);
+                // scale only horizontally, otherwise culling bounding box will be scaled up in y
                 patch.transform.localScale = new Vector3(horizScale, 1f, horizScale);
 
                 patch.AddComponent<OceanChunkRenderer>().SetInstanceData(lodIndex, lodCount, lodDataResolution, geoDownSampleFactor);

--- a/crest/Assets/Crest/Crest/Scripts/OceanBuilder.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanBuilder.cs
@@ -4,8 +4,8 @@
 
 //#define PROFILE_CONSTRUCTION
 
-using UnityEngine;
 using System.Collections;
+using UnityEngine;
 
 namespace Crest
 {
@@ -130,14 +130,14 @@ namespace Crest
         {
             if (lodCount < 1)
             {
-                Debug.LogError( "Invalid LOD count: " + lodCount.ToString(), ocean );
+                Debug.LogError("Invalid LOD count: " + lodCount.ToString(), ocean);
                 return;
             }
 
 #if UNITY_EDITOR
-            if( !UnityEditor.EditorApplication.isPlaying )
+            if (!UnityEditor.EditorApplication.isPlaying)
             {
-                Debug.LogError( "Ocean mesh meant to be (re)generated in play mode", ocean);
+                Debug.LogError("Ocean mesh meant to be (re)generated in play mode", ocean);
                 return;
             }
 #endif
@@ -253,42 +253,42 @@ namespace Crest
             float skirtXminus = 0f, skirtXplus = 0f;
             float skirtZminus = 0f, skirtZplus = 0f;
             // set the patch size
-            if( pt == PatchType.Fat ) { skirtXminus = skirtXplus = skirtZminus = skirtZplus = 1f; }
-            else if( pt == PatchType.FatX || pt == PatchType.FatXOuter ) { skirtXplus = 1f; }
-            else if( pt == PatchType.FatXZ || pt == PatchType.FatXZOuter ) { skirtXplus = skirtZplus = 1f; }
-            else if( pt == PatchType.FatXSlimZ ) { skirtXplus = 1f; skirtZplus = -1f; }
-            else if( pt == PatchType.SlimX ) { skirtXplus = -1f; }
-            else if( pt == PatchType.SlimXZ ) { skirtXplus = skirtZplus = -1f; }
-            else if( pt == PatchType.SlimXFatZ ) { skirtXplus = -1f; skirtZplus = 1f; }
+            if (pt == PatchType.Fat) { skirtXminus = skirtXplus = skirtZminus = skirtZplus = 1f; }
+            else if (pt == PatchType.FatX || pt == PatchType.FatXOuter) { skirtXplus = 1f; }
+            else if (pt == PatchType.FatXZ || pt == PatchType.FatXZOuter) { skirtXplus = skirtZplus = 1f; }
+            else if (pt == PatchType.FatXSlimZ) { skirtXplus = 1f; skirtZplus = -1f; }
+            else if (pt == PatchType.SlimX) { skirtXplus = -1f; }
+            else if (pt == PatchType.SlimXZ) { skirtXplus = skirtZplus = -1f; }
+            else if (pt == PatchType.SlimXFatZ) { skirtXplus = -1f; skirtZplus = 1f; }
 
             float sideLength_verts_x = 1f + vertDensity + skirtXminus + skirtXplus;
             float sideLength_verts_z = 1f + vertDensity + skirtZminus + skirtZplus;
 
             float start_x = -0.5f - skirtXminus * dx;
             float start_z = -0.5f - skirtZminus * dx;
-            float   end_x =  0.5f + skirtXplus * dx;
-            float   end_z =  0.5f + skirtZplus * dx;
+            float end_x = 0.5f + skirtXplus * dx;
+            float end_z = 0.5f + skirtZplus * dx;
 
-            for( float j = 0; j < sideLength_verts_z; j++ )
+            for (float j = 0; j < sideLength_verts_z; j++)
             {
                 // interpolate z across patch
-                float z = Mathf.Lerp( start_z, end_z, j / (sideLength_verts_z - 1f) );
+                float z = Mathf.Lerp(start_z, end_z, j / (sideLength_verts_z - 1f));
 
                 // push outermost edge out to horizon
-                if( pt == PatchType.FatXZOuter && j == sideLength_verts_z - 1f )
+                if (pt == PatchType.FatXZOuter && j == sideLength_verts_z - 1f)
                     z *= 100f;
 
-                for( float i = 0; i < sideLength_verts_x; i++ )
+                for (float i = 0; i < sideLength_verts_x; i++)
                 {
                     // interpolate x across patch
-                    float x = Mathf.Lerp( start_x, end_x, i / (sideLength_verts_x - 1f) );
+                    float x = Mathf.Lerp(start_x, end_x, i / (sideLength_verts_x - 1f));
 
                     // push outermost edge out to horizon
-                    if( i == sideLength_verts_x - 1f && (pt == PatchType.FatXOuter || pt == PatchType.FatXZOuter) )
+                    if (i == sideLength_verts_x - 1f && (pt == PatchType.FatXOuter || pt == PatchType.FatXZOuter))
                         x *= 100f;
 
                     // could store something in y, although keep in mind this is a shared mesh that is shared across multiple lods
-                    verts.Add( new Vector3( x, 0f, z ) );
+                    verts.Add(new Vector3(x, 0f, z));
                 }
             }
 
@@ -299,43 +299,43 @@ namespace Crest
             int sideLength_squares_x = (int)sideLength_verts_x - 1;
             int sideLength_squares_z = (int)sideLength_verts_z - 1;
 
-            for( int j = 0; j < sideLength_squares_z; j++ )
+            for (int j = 0; j < sideLength_squares_z; j++)
             {
-                for( int i = 0; i < sideLength_squares_x; i++ )
+                for (int i = 0; i < sideLength_squares_x; i++)
                 {
                     bool flipEdge = false;
 
-                    if( i % 2 == 1 ) flipEdge = !flipEdge;
-                    if( j % 2 == 1 ) flipEdge = !flipEdge;
+                    if (i % 2 == 1) flipEdge = !flipEdge;
+                    if (j % 2 == 1) flipEdge = !flipEdge;
 
                     int i0 = i + j * (sideLength_squares_x + 1);
                     int i1 = i0 + 1;
                     int i2 = i0 + (sideLength_squares_x + 1);
                     int i3 = i2 + 1;
 
-                    if( !flipEdge )
+                    if (!flipEdge)
                     {
                         // tri 1
-                        indices.Add( i3 );
-                        indices.Add( i1 );
-                        indices.Add( i0 );
+                        indices.Add(i3);
+                        indices.Add(i1);
+                        indices.Add(i0);
 
                         // tri 2
-                        indices.Add( i0 );
-                        indices.Add( i2 );
-                        indices.Add( i3 );
+                        indices.Add(i0);
+                        indices.Add(i2);
+                        indices.Add(i3);
                     }
                     else
                     {
                         // tri 1
-                        indices.Add( i3 );
-                        indices.Add( i1 );
-                        indices.Add( i2 );
+                        indices.Add(i3);
+                        indices.Add(i1);
+                        indices.Add(i2);
 
                         // tri 2
-                        indices.Add( i0 );
-                        indices.Add( i2 );
-                        indices.Add( i1 );
+                        indices.Add(i0);
+                        indices.Add(i2);
+                        indices.Add(i1);
                     }
                 }
             }
@@ -345,18 +345,18 @@ namespace Crest
             // create mesh
 
             Mesh mesh = new Mesh();
-            if( verts != null && verts.Count > 0 )
+            if (verts != null && verts.Count > 0)
             {
                 Vector3[] arrV = new Vector3[verts.Count];
-                verts.CopyTo( arrV );
+                verts.CopyTo(arrV);
 
                 int[] arrI = new int[indices.Count];
-                indices.CopyTo( arrI );
+                indices.CopyTo(arrI);
 
-                mesh.SetIndices( null, MeshTopology.Triangles, 0 );
+                mesh.SetIndices(null, MeshTopology.Triangles, 0);
                 mesh.vertices = arrV;
                 mesh.normals = null;
-                mesh.SetIndices( arrI, MeshTopology.Triangles, 0 );
+                mesh.SetIndices(arrI, MeshTopology.Triangles, 0);
 
                 // recalculate bounds. add a little allowance for snapping. in the chunk renderer script, the bounds will be expanded further
                 // to allow for horizontal displacement
@@ -385,7 +385,7 @@ namespace Crest
             PatchType tlCornerType = generateSkirt ? PatchType.FatXZOuter : PatchType.SlimXFatZ;
             PatchType brCornerType = generateSkirt ? PatchType.FatXZOuter : PatchType.FatXSlimZ;
 
-            if( lodIndex != 0 )
+            if (lodIndex != 0)
             {
                 // instance indices:
                 //    0  1  2  3
@@ -437,17 +437,17 @@ namespace Crest
             // overlap
             if (ocean._uniformTiles)
             {
-                for( int i = 0; i < patchTypes.Length; i++ )
+                for (int i = 0; i < patchTypes.Length; i++)
                 {
                     patchTypes[i] = PatchType.Fat;
                 }
             }
 
             // create the ocean patches
-            for( int i = 0; i < offsets.Length; i++ )
+            for (int i = 0; i < offsets.Length; i++)
             {
                 // instantiate and place patch
-                var patch = new GameObject( string.Format( "Tile_L{0}", lodIndex ) );
+                var patch = new GameObject(string.Format("Tile_L{0}", lodIndex));
                 patch.layer = oceanLayer;
                 patch.transform.parent = ocean.transform;
                 Vector2 pos = offsets[i];
@@ -459,13 +459,13 @@ namespace Crest
 
                 var mr = patch.AddComponent<MeshRenderer>();
 
-                // sorting order to stop unity drawing it back to front. make the innermost 4 tiles draw first, followed by
-                // the rest of the tiles by lod index. all this happens before layer 0 - the sorting layer takes prio over the
-                // render queue it seems! ( https://cdry.wordpress.com/2017/04/28/unity-render-queues-vs-sorting-layers/ ). this pushes
-                // ocean rendering way early, so transparents will by default render afterwards, which is typical for water rendering.
+                // Sorting order to stop unity drawing it back to front. make the innermost 4 tiles draw first, followed by
+                // the rest of the tiles by LOD index. all this happens before layer 0 - the sorting layer takes priority over the
+                // render queue it seems! ( https://cdry.wordpress.com/2017/04/28/unity-render-queues-vs-sorting-layers/ ). This pushes
+                // ocean rendering way early, so transparent objects will by default render afterwards, which is typical for water rendering.
                 mr.sortingOrder = -lodCount + (patchTypes[i] == PatchType.Interior ? -1 : lodIndex);
 
-                // i dont think one would use lightprobes for a purely specular water surface? (although diffuse foam shading would benefit)
+                // I don't think one would use light probes for a purely specular water surface? (although diffuse foam shading would benefit)
                 mr.lightProbeUsage = UnityEngine.Rendering.LightProbeUsage.Off;
                 mr.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off; // arbitrary - could be turned on if desired
                 mr.receiveShadows = false; // this setting is ignored by unity for the transparent ocean shader
@@ -474,33 +474,33 @@ namespace Crest
 
                 // rotate side patches to point the +x side outwards
                 bool rotateXOutwards = patchTypes[i] == PatchType.FatX || patchTypes[i] == PatchType.FatXOuter || patchTypes[i] == PatchType.SlimX || patchTypes[i] == PatchType.SlimXFatZ;
-                if( rotateXOutwards )
+                if (rotateXOutwards)
                 {
-                    if( Mathf.Abs( pos.y ) >= Mathf.Abs( pos.x ) )
-                        patch.transform.localEulerAngles = -Vector3.up * 90f * Mathf.Sign( pos.y );
+                    if (Mathf.Abs(pos.y) >= Mathf.Abs(pos.x))
+                        patch.transform.localEulerAngles = -Vector3.up * 90f * Mathf.Sign(pos.y);
                     else
                         patch.transform.localEulerAngles = pos.x < 0f ? Vector3.up * 180f : Vector3.zero;
                 }
 
                 // rotate the corner patches so the +x and +z sides point outwards
                 bool rotateXZOutwards = patchTypes[i] == PatchType.FatXZ || patchTypes[i] == PatchType.SlimXZ || patchTypes[i] == PatchType.FatXSlimZ || patchTypes[i] == PatchType.FatXZOuter;
-                if( rotateXZOutwards )
+                if (rotateXZOutwards)
                 {
                     // xz direction before rotation
-                    Vector3 from = new Vector3( 1f, 0f, 1f ).normalized;
+                    Vector3 from = new Vector3(1f, 0f, 1f).normalized;
                     // target xz direction is outwards vector given by local patch position - assumes this patch is a corner (checked below)
                     Vector3 to = patch.transform.localPosition.normalized;
-                    if( Mathf.Abs( patch.transform.localPosition.x ) < 0.0001f || Mathf.Abs( Mathf.Abs( patch.transform.localPosition.x ) - Mathf.Abs( patch.transform.localPosition.z ) ) > 0.001f )
+                    if (Mathf.Abs(patch.transform.localPosition.x) < 0.0001f || Mathf.Abs(Mathf.Abs(patch.transform.localPosition.x) - Mathf.Abs(patch.transform.localPosition.z)) > 0.001f)
                     {
-                        Debug.LogWarning( "Skipped rotating a patch because it isn't a corner, click here to highlight.", patch );
+                        Debug.LogWarning("Skipped rotating a patch because it isn't a corner, click here to highlight.", patch);
                         continue;
                     }
 
-                    // detect 180 degree rotations as it doesnt always rotate around Y
-                    if( Vector3.Dot( from, to ) < -0.99f )
+                    // Detect 180 degree rotations as it doesn't always rotate around Y
+                    if (Vector3.Dot(from, to) < -0.99f)
                         patch.transform.localEulerAngles = Vector3.up * 180f;
                     else
-                        patch.transform.localRotation = Quaternion.FromToRotation( from, to );
+                        patch.transform.localRotation = Quaternion.FromToRotation(from, to);
                 }
             }
         }

--- a/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
@@ -106,7 +106,7 @@ namespace Crest
             // geometry data
             // compute grid size of geometry. take the long way to get there - make sure we land exactly on a power of two
             // and not inherit any of the lossy-ness from lossyScale.
-            var scale_pow_2 = Mathf.Pow(2f, Mathf.Round(Mathf.Log(transform.lossyScale.x) / Mathf.Log(2f)));
+            var scale_pow_2 = OceanRenderer.Instance.CalcLodScale(_lodIndex);
             var gridSizeGeo = scale_pow_2 / (0.25f * _lodDataResolution / _geoDownSampleFactor);
             var gridSizeLodData = gridSizeGeo / _geoDownSampleFactor;
             var mul = 1.875f; // fudge 1

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -103,11 +103,16 @@ namespace Crest
         [Tooltip("Move ocean with viewpoint.")]
         public bool _followViewpoint = true;
 
-        float _viewerAltitudeLevelAlpha = 0f;
+        /// <summary>
+        /// Current ocean scale (changes with viewer altitude).
+        /// </summary>
+        public float Scale { get; private set; }
+        public float CalcLodScale(float lodIndex) { return Scale * Mathf.Pow(2f, lodIndex); }
+
         /// <summary>
         /// The ocean changes scale when viewer changes altitude, this gives the interpolation param between scales.
         /// </summary>
-        public float ViewerAltitudeLevelAlpha { get { return _viewerAltitudeLevelAlpha; } }
+        public float ViewerAltitudeLevelAlpha { get; private set; }
 
         /// <summary>
         /// Sea level is given by y coordinate of GameObject with OceanRenderer script.
@@ -142,6 +147,7 @@ namespace Crest
             }
 
             Instance = this;
+            Scale = Mathf.Clamp(Scale, _minScale, _maxScale);
 
             OceanBuilder.GenerateMesh(this, _lodDataResolution, _geometryDownSampleFactor, _lodCount);
 
@@ -263,10 +269,10 @@ namespace Crest
             float l2 = Mathf.Log(level) / Mathf.Log(2f);
             float l2f = Mathf.Floor(l2);
 
-            _viewerAltitudeLevelAlpha = l2 - l2f;
+            ViewerAltitudeLevelAlpha = l2 - l2f;
 
-            float newScale = Mathf.Pow(2f, l2f);
-            transform.localScale = new Vector3(newScale, 1f, newScale);
+            Scale = Mathf.Pow(2f, l2f);
+            transform.localScale = new Vector3(Scale, 1f, Scale);
         }
 
         void LateUpdateViewerHeight()


### PR DESCRIPTION
This is not high priority but would be good to merge in when we're happy master is settled.

I've been meaning to simplify the ocean hierarchy for a long time now, finally got around to doing it. i've removed the intermediate LODx from the hierarchy, which will make it cheaper to update, and the lod scales are now computed instead of being read from transform.lossyScale. I would wager that the unicorn bug where gaps appear in the surface comes from error in the lossy scale.

Oh i couldnt resist running the Format Document command on OceanBuilder which made a LOT of changes. This PR is best reviewed per-commit, rather than Files Changed.