### PR TITLE
Make Linux default to Vulkan API

### DIFF
--- a/crest/ProjectSettings/ProjectSettings.asset
+++ b/crest/ProjectSettings/ProjectSettings.asset
@@ -260,7 +260,10 @@ PlayerSettings:
   m_BuildTargetIcons: []
   m_BuildTargetPlatformIcons: []
   m_BuildTargetBatching: []
-  m_BuildTargetGraphicsAPIs: []
+  m_BuildTargetGraphicsAPIs:
+  - m_BuildTarget: LinuxStandaloneSupport
+    m_APIs: 1500000011000000
+    m_Automatic: 0
   m_BuildTargetVRSettings:
   - m_BuildTarget: Android
     m_Enabled: 0


### PR DESCRIPTION
It's a better default to use as the API supports async GPU readback (unlike OpenGL).